### PR TITLE
added simple data seed of maintenance teams, also removed xpath equipment id that caused trouble. 

### DIFF
--- a/onecore_maintenance_extension/__manifest__.py
+++ b/onecore_maintenance_extension/__manifest__.py
@@ -13,6 +13,10 @@
       'security/maintenance.xml',
       'security/ir.model.access.csv',
       'views/maintenance_views.xml',
+
+      # Load initial Data
+      'data/maintenance.team.csv'
+
     ],
     'auto_install': True,
     'license': 'LGPL-3',

--- a/onecore_maintenance_extension/data/maintenance.team.csv
+++ b/onecore_maintenance_extension/data/maintenance.team.csv
@@ -1,0 +1,7 @@
+"id","name"
+"1","Vitvarureperatör Mimer"
+"2","Område Väst"
+"3","Område Öst"
+"4","Område Norr"
+"5","Område Mitt"
+"6","Område Student"

--- a/onecore_maintenance_extension/views/maintenance_views.xml
+++ b/onecore_maintenance_extension/views/maintenance_views.xml
@@ -20,7 +20,7 @@
                     <attribute name="class">w-auto</attribute>
                 </xpath>
                 <!-- Removes existing fields from first group -->
-                <!-- <xpath expr="//field[@name='equipment_id'] | //field[@name='category_id'] | //field[@name='request_date']" position="replace"/> -->
+               
                 <!-- Add new fields to first group -->
                 <xpath expr="//field[@name='owner_user_id']" position="after">
                     <field name="rental_property_option_id" string="Hyresobjekt" options="{'no_create_edit': True, 'no_create':True, 'no_open': True}" groups="maintenance.group_equipment_manager"/>


### PR DESCRIPTION
populates the database with 6 different mimer teams from a csv when the maintenance app is upgraded. 

if the teams are already there nothing happens. 