### PR TITLE
MIM-114: Make it possible to save maintenance request without maintenance unit

### DIFF
--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -278,7 +278,7 @@ class OneCoreMaintenanceRequest(models.Model):
         images = []
         for vals in vals_list:
             # SAVE RENTAL PROPERTY
-            if 'rental_property_option_id' in vals:
+            if vals['rental_property_option_id']:
                 property_option_record = self.env['maintenance.rental.property.option'].search([('id', '=', vals.get('rental_property_option_id'))])
                 new_property_record = self.env['maintenance.rental.property'].create({
                     'name': property_option_record.name,
@@ -312,7 +312,7 @@ class OneCoreMaintenanceRequest(models.Model):
                 vals['maintenance_unit_id'] = new_maintenance_unit_record.id
 
             # SAVE LEASE
-            if 'lease_option_id' in vals:
+            if vals['lease_option_id']:
                 lease_option_record = self.env['maintenance.lease.option'].search([('id', '=', vals.get('lease_option_id'))])
                 new_lease_record = self.env['maintenance.lease'].create({
                     'lease_id': lease_option_record.name,
@@ -328,7 +328,7 @@ class OneCoreMaintenanceRequest(models.Model):
                 vals['lease_id'] = new_lease_record.id
 
             # SAVE TENANT
-            if 'tenant_option_id' in vals:
+            if vals['tenant_option_id']:
                 tenant_option_record = self.env['maintenance.tenant.option'].search([('id', '=', vals.get('tenant_option_id'))])
                 new_tenant_record = self.env['maintenance.tenant'].create({
                     'name': tenant_option_record.name,

--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -300,7 +300,7 @@ class OneCoreMaintenanceRequest(models.Model):
                 vals['rental_property_id'] = new_property_record.id
 
             # SAVE MAINTENANCE UNIT
-            if 'maintenance_unit_option_id' in vals:
+            if vals['maintenance_unit_option_id']:
                 maintenance_unit_option_record = self.env['maintenance.maintenance.unit.option'].search([('id', '=', vals.get('maintenance_unit_option_id'))])
                 new_maintenance_unit_record = self.env['maintenance.maintenance.unit'].create({
                     'name': maintenance_unit_option_record.name,


### PR DESCRIPTION
`'maintenance_unit_option_id' in vals` is true even if the value of `vals['maintenance_unit_option_id']` is false, so it would fail when trying to save the maintenance unit.

Should maybe change all the `if 'x' in vals` checks in this method? We can do it in a separate PR that we don't merge until after release though in case it unexpectedly breaks something.