### PR TITLE
added functionality for timereporting for Mimer in errands

### DIFF
--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -1006,7 +1006,6 @@ class OneCoreMaintenanceRequest(models.Model):
         # Get the base URL from system parameters
         base_url = (
             self.env["ir.config_parameter"]
-            .sudo()
             .get_param(
                 "time_report_base_url",
                 "https://apps.mimer.nu/version-test/tidsrapportering/",

--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -990,7 +990,43 @@ class OneCoreMaintenanceRequest(models.Model):
             #     _logger.info(f"Webhook not sent. rental_property_option_id is missing for Maintenance Request ID: {request.id}")
 
         return maintenance_requests
+    
+    def open_time_report(self):
+        """
+        Open the time report application in a new window.
+        The function passes the estate code as a URL parameter 'p'
+        and the maintenance request ID as a URL parameter 'od'.
+        """
+        self.ensure_one()
+        # Get estate code from either rental property or maintenance unit
+        estate_code = False
+        if self.rental_property_id and self.rental_property_id.estate_code:
+            estate_code = self.rental_property_id.estate_code
+        elif self.maintenance_unit_id and self.maintenance_unit_id.estate_code:
+            estate_code = self.maintenance_unit_id.estate_code
 
+        # Get the base URL from system parameters
+        base_url = self.env['ir.config_parameter'].sudo().get_param('time_report_base_url', 'https://apps.mimer.nu/version-test/tidsrapportering/')
+        
+        # Construct the URL with both estate code and maintenance request ID
+        url = base_url
+        params = []
+        if estate_code:
+            params.append(f"p={estate_code}")
+        
+        # Always add the maintenance request ID
+        params.append(f"od={self.id}")
+        
+        # Join parameters with & if there are multiple
+        if params:
+            url += "?" + "&".join(params)
+                
+        return {
+            'type': 'ir.actions.act_url',
+            'url': url,
+            'target': 'new',  # Opens in a new tab/window
+        }
+        
     def write(self, vals):
         if "stage_id" in vals:
             if self.env.user.has_group(

--- a/onecore_maintenance_extension/views/maintenance_views.xml
+++ b/onecore_maintenance_extension/views/maintenance_views.xml
@@ -400,11 +400,13 @@
                                             name="schedule_date"
                                             help="Det datum arbete är planerat"
                                         />
+                                        
                                         <field
                                             name="master_key" string="Huvudnyckel"
                                             widget="boolean_toggle"
                                             invisible="space_caption != 'Lägenhet'"
                                             readonly="user_is_external_contractor" />
+                                            
                                         <field
                                             name="call_between" invisible="not call_between"
                                             string="Kund nås dessa tider"
@@ -420,6 +422,13 @@
                                         <field
                                             name="user_is_external_contractor" invisible="1" />
                                     </group>
+                                    <button name="open_time_report" 
+                                                type="object" 
+                                                string="Öppna tidrapport" 
+                                                icon="fa-clock-o"
+                                                class="btn btn-secondary mt-2 mb-2"
+                                                help="Öppna tidrapporteringssystem"
+                                                invisible="user_is_external_contractor"/>
                                 </div>
                             </div>
                         </div>
@@ -548,5 +557,11 @@
         <record id="base.menu_management" model="ir.ui.menu">
             <field name="groups_id" eval="[(6, 0, [ref('base.group_system'),])]" />
         </record>
+        
+        <record id="time_report_base_url" model="ir.config_parameter">
+    <field name="key">time_report_base_url</field>
+    <field name="value">https://timereport.example.com</field>
+</record>
+        
     </data>
 </odoo>

--- a/onecore_maintenance_extension/views/maintenance_views.xml
+++ b/onecore_maintenance_extension/views/maintenance_views.xml
@@ -400,13 +400,13 @@
                                             name="schedule_date"
                                             help="Det datum arbete är planerat"
                                         />
-                                        
+
                                         <field
                                             name="master_key" string="Huvudnyckel"
                                             widget="boolean_toggle"
                                             invisible="space_caption != 'Lägenhet'"
                                             readonly="user_is_external_contractor" />
-                                            
+
                                         <field
                                             name="call_between" invisible="not call_between"
                                             string="Kund nås dessa tider"
@@ -422,13 +422,13 @@
                                         <field
                                             name="user_is_external_contractor" invisible="1" />
                                     </group>
-                                    <button name="open_time_report" 
-                                                type="object" 
-                                                string="Öppna tidrapport" 
-                                                icon="fa-clock-o"
-                                                class="btn btn-secondary mt-2 mb-2"
-                                                help="Öppna tidrapporteringssystem"
-                                                invisible="user_is_external_contractor"/>
+                                    <button name="open_time_report"
+                                        type="object"
+                                        string="Öppna tidrapport"
+                                        icon="fa-clock-o"
+                                        class="btn btn-secondary mt-2 mb-2"
+                                        help="Öppna tidrapporteringssystem"
+                                        invisible="user_is_external_contractor" />
                                 </div>
                             </div>
                         </div>
@@ -557,11 +557,5 @@
         <record id="base.menu_management" model="ir.ui.menu">
             <field name="groups_id" eval="[(6, 0, [ref('base.group_system'),])]" />
         </record>
-        
-        <record id="time_report_base_url" model="ir.config_parameter">
-    <field name="key">time_report_base_url</field>
-    <field name="value">https://timereport.example.com</field>
-</record>
-        
     </data>
 </odoo>


### PR DESCRIPTION
this change requires a **system parameter** in odoo called **time_report_base_url**

**Test and local:**
https://apps.mimer.nu/version-test/tidsrapportering for test

**Production:**
https://apps.mimer.nu/tidsrapportering


The button will redirect the user to the page in a new window sending both the propertyId and odoo id as url parameters. 

only visibile for Mimer and not external contractors. 

![image](https://github.com/user-attachments/assets/04d9643d-bb1a-4fa4-a62c-74acb24cd9c3)
