### PR TITLE
enable kanban lazy loading with limit=30

### DIFF
--- a/onecore_maintenance_extension/views/maintenance_views.xml
+++ b/onecore_maintenance_extension/views/maintenance_views.xml
@@ -474,6 +474,10 @@
             <field name="model">maintenance.request</field>
             <field name="inherit_id" ref="maintenance.hr_equipment_request_view_kanban" />
             <field name="arch" type="xml">
+
+                <xpath expr="//kanban" position="attributes">
+                    <attribute name="limit">30</attribute>
+                </xpath>
                 <xpath expr="//field[@name='archive']" position="after">
                     <field name="stage_id" />
                     <field name="color" />


### PR DESCRIPTION
## PR: Enable Lazy Loading in Kanban View for Maintenance Requests

### Summary

This pull request enables lazy loading in the Kanban view for the `maintenance.request` model by setting a limit of 30 records per column. This improves performance and scalability when working with a large number of maintenance records.

### What’s Changed

- Modified the `hr_equipment_request_view_kanban_extension` view.
- Added the `limit="30"` attribute to the `<kanban>` tag to trigger Odoo’s built-in lazy loading behavior.

### Why

Without lazy loading, all records in each Kanban column are loaded at once. This can cause performance degradation when there are many records in a single stage. By limiting the initial load and progressively loading more records while scrolling, we improve:

- Initial load times
- UI responsiveness
- User experience for teams managing high volumes of maintenance requests

### How to Test

1. Open the Kanban view for **Maintenance Requests**.
2. Scroll down within any column that has more than 30 records.
3. Confirm that additional records are loaded dynamically via background requests.

### Notes

- This change is purely frontend (view XML); no backend logic was modified.
- It uses Odoo’s native lazy loading support—no custom JavaScript was introduced.
- The existing card rendering (`t-call`) and fields remain intact.

![image](https://github.com/user-attachments/assets/78f22e5c-d0bc-41da-8813-12fcc8335a06)


