### PR TITLE
count 'Väntar på handläggning on team view'

### DIFF
--- a/onecore_maintenance_extension/__manifest__.py
+++ b/onecore_maintenance_extension/__manifest__.py
@@ -13,7 +13,7 @@
         "security/maintenance.xml",
         "security/ir.model.access.csv",
         "views/maintenance_views.xml",
-        "views/maintenance_team_view",
+        "views/maintenance_team_view.xml",
         "views/mobile_view.xml",
         # Load initial Data
         "data/maintenance.team.csv",

--- a/onecore_maintenance_extension/__manifest__.py
+++ b/onecore_maintenance_extension/__manifest__.py
@@ -13,6 +13,7 @@
         "security/maintenance.xml",
         "security/ir.model.access.csv",
         "views/maintenance_views.xml",
+        "views/maintenance_team_view",
         "views/mobile_view.xml",
         # Load initial Data
         "data/maintenance.team.csv",

--- a/onecore_maintenance_extension/models/__init__.py
+++ b/onecore_maintenance_extension/models/__init__.py
@@ -5,3 +5,4 @@ from . import maintenance_rental_property
 from . import maintenance_tenant
 from . import maintenance_maintenance_unit
 from . import maintenance_request_category
+from . import maintenance_team

--- a/onecore_maintenance_extension/models/maintenance_team.py
+++ b/onecore_maintenance_extension/models/maintenance_team.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models
+
+class MaintenanceTeam(models.Model):
+    _inherit = 'maintenance.team'
+    
+    first_column_request_count = fields.Integer(
+        compute='_compute_first_column_request_count',
+        string="First Column Requests"
+    )
+    
+    @api.depends('todo_request_ids')
+    def _compute_first_column_request_count(self):
+        """Compute the count of requests in the first column for each team"""
+        stages = self.env['maintenance.stage'].search([], order='sequence')
+        first_stage = stages[0] if stages else False
+        
+        for team in self:
+            if first_stage:
+                team.first_column_request_count = self.env['maintenance.request'].search_count([
+                    ('maintenance_team_id', '=', team.id),
+                    ('stage_id', '=', first_stage.id)
+                ])
+            else:
+                team.first_column_request_count = 0

--- a/onecore_maintenance_extension/views/maintenance_team_view.xml
+++ b/onecore_maintenance_extension/views/maintenance_team_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="maintenance_team_kanban_extension" model="ir.ui.view">
+        <field name="name">maintenance.team.kanban.extension</field>
+        <field name="model">maintenance.team</field>
+        <field name="inherit_id" ref="maintenance.maintenance_team_kanban"/>
+        <field name="arch" type="xml">
+            <!-- Add the new field to the view -->
+            <xpath expr="//field[@name='todo_request_count_unscheduled']" position="after">
+                <field name="first_column_request_count"/>
+            </xpath>
+            
+            <!-- Replace the "Scheduled" item in the right column with our custom count -->
+            <xpath expr="//div[@class='col-6 o_kanban_primary_right']/div[1]" position="replace">
+                <div t-if="record.first_column_request_count.raw_value > 0">
+                    <a name="%(maintenance.hr_equipment_todo_request_action_from_dashboard)d" type="action">
+                        <t t-esc="record.first_column_request_count.value"/>
+                        Väntar på handläggning
+                    </a>
+                </div>
+            </xpath>
+            
+            <!-- Remove the "Unscheduled" item from the right column -->
+            <xpath expr="//div[@class='col-6 o_kanban_primary_right']/div[4]" position="replace">
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
# Replace "Scheduled" and "Unscheduled" with first column counts in teams section

## Overview
Enhances the "teams overview section" by replacing the "Scheduled" and "Unscheduled" sections with a count of requests in the first kanban column ("Väntar på handläggning"). This change provides a more relevant view of the work queue for each  team.

## Changes
- Added a computed field `first_column_request_count` to the `maintenance.team` model
- Extended the maintenance team kanban view to display this count instead of the "Scheduled" section
- Removed the "Unscheduled" section which was not being used

## Implementation Details
- Created a new model extension to compute the count of requests in the first stage for each team
- computes the first stage by sequence number rather than hardcoding stage names.
- Updated the manifest to include the new view file.

## Screenshots

### Before: 

![image](https://github.com/user-attachments/assets/2563cd86-130c-428d-a35a-ff6855902233)

### After:

![image](https://github.com/user-attachments/assets/f322811d-afbd-47ee-8c28-b0bf3cfc1f24)


