### PR TITLE
MIM-484: Put maintenance requests with recently added tenant first when sorting

### DIFF
--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -28,6 +28,7 @@ def is_local():
 
 class OneCoreMaintenanceRequest(models.Model):
     _inherit = "maintenance.request"
+    _order = "recently_added_tenant desc, request_date desc"
 
     uuid = fields.Char(
         string="UUID", default=lambda self: str(uuid.uuid4()), readonly=True, copy=False


### PR DESCRIPTION
This changes the ordering on every view, not only kanban, but I assume that is what we want? Otherwise we can set the `default_order` on individual views.