### PR TITLE
fix: mim-1546 - don't close details accordion when selecting priority on mobile

### DIFF
--- a/onecore_maintenance_extension/static/src/js/accordion_state.js
+++ b/onecore_maintenance_extension/static/src/js/accordion_state.js
@@ -1,0 +1,56 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { FormRenderer } from "@web/views/form/form_renderer";
+import { onPatched, onMounted } from "@odoo/owl";
+
+patch(FormRenderer.prototype, {
+  setup() {
+    super.setup();
+    this._openAccordionIds = new Set();
+
+    const restoreAccordions = () => {
+      for (const id of this._openAccordionIds) {
+        const el = document.getElementById(id);
+        if (el && !el.classList.contains("show")) {
+          el.classList.add("show");
+          // Update the button's aria-expanded and collapsed class
+          const button = document.querySelector(
+            `[data-bs-target="#${id}"]`
+          );
+          if (button) {
+            button.classList.remove("collapsed");
+            button.setAttribute("aria-expanded", "true");
+          }
+        }
+      }
+    };
+
+    onMounted(() => {
+      this._bindAccordionListeners();
+      restoreAccordions();
+    });
+
+    onPatched(() => {
+      this._bindAccordionListeners();
+      restoreAccordions();
+    });
+  },
+
+  _bindAccordionListeners() {
+    const accordion = document.getElementById("accordionFlush");
+    if (!accordion || accordion._accordionListenersBound) return;
+    accordion._accordionListenersBound = true;
+
+    accordion.addEventListener("shown.bs.collapse", (ev) => {
+      if (ev.target.id) {
+        this._openAccordionIds.add(ev.target.id);
+      }
+    });
+    accordion.addEventListener("hidden.bs.collapse", (ev) => {
+      if (ev.target.id) {
+        this._openAccordionIds.delete(ev.target.id);
+      }
+    });
+  },
+});


### PR DESCRIPTION
Not a bug related to odoo 19 (works like this in odoo 17 as well).

A request to keep the mobile accordions open after a value i changed in the maintenance request mobile view - for example changing "priority". 

This used to close the accordion which was a bit annoying UX wise.