### PR TITLE
removed odoo-bot messages and channel

### DIFF
--- a/onecore_base_extension/__init__.py
+++ b/onecore_base_extension/__init__.py
@@ -1,1 +1,2 @@
 # __init__.py
+from . import models

--- a/onecore_base_extension/__manifest__.py
+++ b/onecore_base_extension/__manifest__.py
@@ -6,9 +6,14 @@
     "summary": "Extends the Odoo base module with ONECore specific customizations.",
     "sequence": 100,
     "version": "19.0.1.0.0",
-    "depends": ["base"],
+    "depends": ["base", "mail_bot", "mail"],
     "data": [
         "views/res_users_view.xml",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "onecore_base_extension/static/src/xml/messaging_menu.xml",
+        ],
+    },
     "auto_install": True,
 }

--- a/onecore_base_extension/models/__init__.py
+++ b/onecore_base_extension/models/__init__.py
@@ -1,0 +1,2 @@
+from . import mail_bot
+from . import res_users

--- a/onecore_base_extension/models/mail_bot.py
+++ b/onecore_base_extension/models/mail_bot.py
@@ -1,0 +1,31 @@
+from odoo import api, models
+
+
+class MailBot(models.AbstractModel):
+    _inherit = "mail.bot"
+
+    def _apply_logic(self, channel, values, command=None):
+        # Completely disable OdooBot responses
+        return
+
+    @api.model
+    def _register_hook(self):
+        """Disable OdooBot for all existing users and remove OdooBot channels on module load."""
+        super()._register_hook()
+        odoobot = self.env.ref("base.partner_root", raise_if_not_found=False)
+        if not odoobot:
+            return
+
+        # Set all users to disabled
+        self.env.cr.execute(
+            "UPDATE res_users SET odoobot_state = 'disabled' "
+            "WHERE odoobot_state IS NULL OR odoobot_state != 'disabled'"
+        )
+
+        # Remove existing OdooBot direct message channels
+        channels = self.env["discuss.channel"].search([
+            ("channel_type", "=", "chat"),
+            ("channel_member_ids.partner_id", "=", odoobot.id),
+        ])
+        if channels:
+            channels.sudo().unlink()

--- a/onecore_base_extension/models/res_users.py
+++ b/onecore_base_extension/models/res_users.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def _on_webclient_bootstrap(self):
+        # Set state to disabled before super() so mail_bot skips _init_odoobot()
+        if self._is_internal() and self.odoobot_state in [False, "not_initialized"]:
+            self.sudo().odoobot_state = "disabled"
+        super()._on_webclient_bootstrap()

--- a/onecore_base_extension/static/src/xml/messaging_menu.xml
+++ b/onecore_base_extension/static/src/xml/messaging_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.MessagingMenu.content" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='installationRequest.isShown and !store.discuss.searchTerm']" position="attributes">
+            <attribute name="t-if">false</attribute>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
 ## Summary      
  - Completely disable OdooBot chatbot —
  prevents initialization on login, silences 
  all bot responses, and removes existing
  OdooBot chat channels on module update     
  - Hide the PWA "Install the app" prompt
  from the messaging menu

  ## Changes

  ### OdooBot disabled
  - **`models/res_users.py`** — Overrides
  `_on_webclient_bootstrap()` to set
  `odoobot_state = 'disabled'` before the bot
   can initialize, preventing new OdooBot
  channels from being created
  - **`models/mail_bot.py`** — Overrides
  `_apply_logic()` as a no-op so the bot
  never responds to any messages. Adds
  `_register_hook()` to clean up existing
  users and OdooBot channels on module load
  - **`__manifest__.py`** — Added `mail_bot`
  and `mail` as dependencies

  ### PWA install prompt hidden
  - **`static/src/xml/messaging_menu.xml`** —
   Template override that hides the "Come
  here often? Install the app" notification
  from the messaging menu

  ## Test plan
  - [ ] Restart Odoo with `-u
  onecore_base_extension`
  - [ ] Log in — verify no OdooBot chat
  channel appears in the sidebar
  - [ ] If an OdooBot channel existed before,
   verify it has been removed
  - [ ] Open the messaging menu — verify no
  "Install the app" prompt appears
  - [ ] Send messages in channels — verify
  OdooBot does not respond