### PR TITLE
Restore YYYY-MM-DD date format (MIM-1638)

### DIFF
--- a/onecore_base_extension/__manifest__.py
+++ b/onecore_base_extension/__manifest__.py
@@ -5,9 +5,10 @@
     "category": "ONECore",
     "summary": "Extends the Odoo base module with ONECore specific customizations.",
     "sequence": 100,
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "depends": ["base", "mail_bot", "mail"],
     "data": [
+        "data/res_lang_data.xml",
         "views/res_users_view.xml",
     ],
     "assets": {

--- a/onecore_base_extension/data/res_lang_data.xml
+++ b/onecore_base_extension/data/res_lang_data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <!-- MIM-1638: Align English (US) date format with Swedish ISO convention.
+             Mimer is a Swedish customer; en_US users should still see
+             2026-04-29 rather than 04/29/2026. -->
+        <record id="base.lang_en" model="res.lang">
+            <field name="date_format">%Y-%m-%d</field>
+        </record>
+    </data>
+</odoo>

--- a/onecore_ui/static/src/js/patch_date_formatters.js
+++ b/onecore_ui/static/src/js/patch_date_formatters.js
@@ -1,0 +1,42 @@
+/** @odoo-module **/
+/**
+ * MIM-1638: Restore pre-Odoo 19 date/datetime field rendering.
+ *
+ * Odoo 19 changed @web/views/fields/formatters.js so that the default
+ * formatDate / formatDateTime path calls toLocaleDateString /
+ * toLocaleDateTimeString — which use the browser's Luxon locale and
+ * strip the year when it matches the current year. This ignores
+ * res.lang.date_format entirely and produces outputs like "Apr 9" or
+ * "4 maj 2027" instead of "2026-04-09" / "2027-05-04".
+ *
+ * Override the registry entries so all date/datetime field rendering
+ * goes through the lang-aware helpers from @web/core/l10n/dates that
+ * still honor localization.dateFormat (derived from res.lang).
+ */
+import { registry } from "@web/core/registry";
+import {
+    formatDate as langFormatDate,
+    formatDateTime as langFormatDateTime,
+} from "@web/core/l10n/dates";
+
+const formatters = registry.category("formatters");
+
+function formatDate(value, options = {}) {
+    return langFormatDate(value, options);
+}
+formatDate.extractOptions = () => ({});
+
+function formatDateTime(value, options = {}) {
+    if (options?.showTime === false) {
+        return langFormatDate(value, options);
+    }
+    return langFormatDateTime(value, options);
+}
+formatDateTime.extractOptions = ({ options } = {}) => ({
+    showSeconds: Boolean(options?.show_seconds ?? false),
+    showTime: Boolean(options?.show_time ?? true),
+    showDate: Boolean(options?.show_date ?? true),
+});
+
+formatters.add("date", formatDate, { force: true });
+formatters.add("datetime", formatDateTime, { force: true });


### PR DESCRIPTION
## Fix: Restore `YYYY-MM-DD` date format (MIM-1638)

**Problem:** After Odoo 17→19 upgrade, dates render as `29 maj 2026` instead of `2026-05-29`.

**Cause:** Odoo 19's `formatDate` now calls `toLocaleDateString` (Luxon locale + strips current year), ignoring `res.lang.date_format` entirely.

**Fix:**
- `onecore_ui/static/src/js/patch_date_formatters.js` — override `date`/`datetime` entries in the `formatters` registry to use the lang-aware helpers from `@web/core/l10n/dates`. Covers kanban, list, form, and mobile card in one file.
- `onecore_base_extension/data/res_lang_data.xml` — set `en_US.date_format = %Y-%m-%d` so English-UI users also get ISO dates.
- Manifest: register the data file, bump version to `19.0.1.0.1`.

**Test plan:**
- [ ] Upgrade modules, hard-refresh browser
- [ ] Maintenance Requests kanban/list/form/mobile show `YYYY-MM-DD` on both `sv_SE` and `en_US`


