### PR TITLE
mim-1703: handle opening create maintenance request urls from onecore in odoo 19

### DIFF
--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -397,6 +397,32 @@ class OneCoreMaintenanceRequest(
             if result and isinstance(result, dict) and result.get("warning"):
                 return result
 
+        # After search, check if a specific maintenance unit was requested via URL context.
+        # Check both direct context (Odoo 19 client action path) and params.context
+        # (legacy URL parameter path) for the maintenance unit code.
+        url_context = {}
+        params = self.env.context.get("params", {})
+        if "context" in params and isinstance(params["context"], str):
+            try:
+                url_context = json.loads(params["context"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        mu_code = self.env.context.get(
+            "default_maintenance_unit_code"
+        ) or url_context.get("default_maintenance_unit_code")
+
+        if mu_code:
+            unit = self.env["maintenance.maintenance.unit.option"].search(
+                [
+                    ("code", "=", mu_code),
+                    ("user_id", "=", self.env.user.id),
+                ],
+                limit=1,
+            )
+            if unit:
+                self.maintenance_unit_option_id = unit
+
     # ============================================================================
     # ONCHANGE METHODS
     # ============================================================================
@@ -527,11 +553,15 @@ class OneCoreMaintenanceRequest(
         # for create_related_records but must not be cached by the ORM
         # (Odoo 19 web_read would try to resolve deleted option records)
         _option_fields = {
-            'property_option_id', 'building_option_id',
-            'rental_property_option_id', 'maintenance_unit_option_id',
-            'tenant_option_id', 'lease_option_id',
-            'parking_space_option_id', 'facility_option_id',
-            'staircase_option_id',
+            "property_option_id",
+            "building_option_id",
+            "rental_property_option_id",
+            "maintenance_unit_option_id",
+            "tenant_option_id",
+            "lease_option_id",
+            "parking_space_option_id",
+            "facility_option_id",
+            "staircase_option_id",
         }
         option_vals_list = []
         for vals in vals_list:
@@ -588,7 +618,9 @@ class OneCoreMaintenanceRequest(
             external_contractor_service.validate_stage_transition(
                 self, vals["stage_id"]
             )
-            stage_updates = stage_manager.handle_stage_change(self, vals["stage_id"], vals)
+            stage_updates = stage_manager.handle_stage_change(
+                self, vals["stage_id"], vals
+            )
             vals.update(stage_updates)
 
         # Handle resource assignment workflow (always run, even during creation)
@@ -612,11 +644,15 @@ class OneCoreMaintenanceRequest(
         # Strip transient option fields from vals to prevent Odoo 19
         # web_read from caching and resolving deleted option records
         _option_fields = {
-            'property_option_id', 'building_option_id',
-            'rental_property_option_id', 'maintenance_unit_option_id',
-            'tenant_option_id', 'lease_option_id',
-            'parking_space_option_id', 'facility_option_id',
-            'staircase_option_id',
+            "property_option_id",
+            "building_option_id",
+            "rental_property_option_id",
+            "maintenance_unit_option_id",
+            "tenant_option_id",
+            "lease_option_id",
+            "parking_space_option_id",
+            "facility_option_id",
+            "staircase_option_id",
         }
         for f in _option_fields:
             vals.pop(f, None)

--- a/onecore_maintenance_extension/static/src/js/url_context_action.js
+++ b/onecore_maintenance_extension/static/src/js/url_context_action.js
@@ -1,0 +1,35 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+/**
+ * Client action that acts as a bridge for opening the maintenance request
+ * create form with context from URL parameters.
+ *
+ * In Odoo 19, window actions (ir.actions.act_window) no longer receive URL
+ * parameters in their context. Client actions still do via action.params.
+ * This action reads the context JSON from URL params and forwards it to the
+ * real window action as additionalContext.
+ */
+async function maintenanceCreateFromUrl(env, action) {
+  const params = action.params || {};
+  const contextStr = params.context;
+  let additionalContext = {};
+
+  if (typeof contextStr === "string") {
+    try {
+      additionalContext = JSON.parse(contextStr);
+    } catch (e) {
+      console.warn("Failed to parse maintenance request context from URL:", e);
+    }
+  }
+
+  await env.services.action.doAction(
+    "onecore_maintenance_extension.action_maintenance_request_create",
+    { additionalContext, clearBreadcrumbs: true }
+  );
+}
+
+registry
+  .category("actions")
+  .add("maintenance_create_from_url", maintenanceCreateFromUrl);


### PR DESCRIPTION
Context seems to be handled differently in odoo 19, so in order to parse values coming from OneCore there needs to be a handler for it. 

