### PR TITLE
mim-1699: hide time field from datepicker in odoo 19

### DIFF
--- a/onecore_maintenance_extension/static/src/js/datetime_hide_time.js
+++ b/onecore_maintenance_extension/static/src/js/datetime_hide_time.js
@@ -1,0 +1,22 @@
+/** @odoo-module */
+import { patch } from "@web/core/utils/patch";
+import { DateTimeField } from "@web/views/fields/datetime/datetime_field";
+
+/**
+ * Patch DateTimeField so that options="{'show_time': false}" also hides
+ * the time picker in the popup (not just in the display formatting).
+ *
+ * The base implementation only uses showTime for formatting the input value.
+ * The picker popup always shows the time section when field.type === "datetime".
+ * By overriding the `field` getter to report type "date" when showTime is false,
+ * the picker treats it as a date-only field: no time section, auto-close on select.
+ */
+patch(DateTimeField.prototype, {
+  get field() {
+    const field = super.field;
+    if (this.props.showTime === false) {
+      return { ...field, type: "date" };
+    }
+    return field;
+  },
+});

--- a/onecore_maintenance_extension/views/maintenance_views.xml
+++ b/onecore_maintenance_extension/views/maintenance_views.xml
@@ -527,18 +527,22 @@
                                         <field name="national_registration_number"
                                             invisible="not national_registration_number"
                                             string="Person/Org. nr" />
-                                        <div class="d-flex align-items-center" invisible="not contact_code">
+                                        <div class="d-flex align-items-center"
+                                            invisible="not contact_code">
                                             <label for="contact_code" string="Kundnummer" />
                                             <button name="open_customer_card" type="object"
                                                 class="btn btn-link p-0 ms-1 d-inline-flex align-items-center"
                                                 style="line-height: 1;"
                                                 title="Öppna kundkort i OneCore"
                                                 invisible="user_is_external_contractor or not id">
-                                                <img src="/onecore_maintenance_extension/static/src/img/onecore_simple_black.svg"
-                                                    style="width: 12px; height: 12px;" alt="Kundkort" />
+                                                <img
+                                                    src="/onecore_maintenance_extension/static/src/img/onecore_simple_black.svg"
+                                                    style="width: 12px; height: 12px;"
+                                                    alt="Kundkort" />
                                             </button>
                                         </div>
-                                        <field name="contact_code" nolabel="1" invisible="not contact_code" />
+                                        <field name="contact_code" nolabel="1"
+                                            invisible="not contact_code" />
 
                                         <!-- Phone number and email address should only be editable
                                         for equipment managers -->
@@ -608,10 +612,12 @@
                                             help="Det datum ärendet ska vara utfört"
                                             readonly="user_is_external_contractor" />
                                         <field name="performed_date"
-                                            help="Datum och tid då ärendet markerades som utfört"
+                                            options="{'show_time': false}"
+                                            help="Datum då ärendet markerades som utfört"
                                             readonly="1" />
                                         <field name="closed_date"
-                                            help="Datum och tid då ärendet markerades som avslutat"
+                                            options="{'show_time': false}"
+                                            help="Datum då ärendet markerades som avslutat"
                                             readonly="1" />
                                         <field
                                             name="maintenance_request_category_id"
@@ -625,6 +631,7 @@
                                             domain="maintenance_team_domain" />
                                         <field
                                             name="schedule_date"
+                                            options="{'show_time': false}"
                                             help="Det datum arbete är planerat"
                                         />
 
@@ -792,10 +799,10 @@
                         <field name="user_id" optional="show" />
                         <field name="maintenance_team_id" optional="show" />
                         <field name="start_date" optional="hide" />
-                        <field name="schedule_date" optional="hide" />
+                        <field name="schedule_date" options="{'show_time': false}" optional="hide" />
                         <field name="due_date" optional="show" />
-                        <field name="performed_date" optional="hide" />
-                        <field name="closed_date" optional="hide" />
+                        <field name="performed_date" options="{'show_time': false}" optional="hide" />
+                        <field name="closed_date" options="{'show_time': false}" optional="hide" />
                         <field name="maintenance_request_category_id" optional="hide" />
                         <field name="priority_expanded" optional="hide" />
                         <field name="creation_origin" optional="hide" />
@@ -834,7 +841,7 @@
             <field name="target">current</field>
             <field name="context">{
                 'form_view_initial_mode': 'edit',
-            }</field>
+                }</field>
         </record>
 
         <menuitem


### PR DESCRIPTION
Updating to odoo 19 seems to have introduced a time field in the date picker component.


Before:
<img width="410" height="267" alt="Screenshot 2026-04-21 at 14 17 33" src="https://github.com/user-attachments/assets/9dbad582-754e-4a54-80e9-6514907b6f98" />

After:
<img width="336" height="271" alt="Screenshot 2026-04-21 at 14 50 04" src="https://github.com/user-attachments/assets/f454727e-4ebd-4537-be8a-15e30ef2b6b7" />
