### PR TITLE
mim-1701: prompt user to save instead of auto-saving maintenance request (chatter component)

### DIFF
--- a/onecore_mail_extension/static/src/tenant/tenant_chatter_patch.js
+++ b/onecore_mail_extension/static/src/tenant/tenant_chatter_patch.js
@@ -1,0 +1,59 @@
+/** @odoo-module **/
+
+import { Chatter } from "@mail/chatter/web_portal/chatter";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+
+// Odoo's Chatter auto-saves the underlying record when Send message / Log note /
+// Activity is clicked on an unsaved record. For maintenance.request this triggers
+// the creation SMS to the tenant (HG = hyresgäst) before the user has confirmed —
+// see MIM-1701. Gate these actions behind an explicit confirmation dialog.
+patch(Chatter.prototype, {
+  setup() {
+    super.setup();
+    this.dialogService = this.env.services.dialog;
+  },
+
+  _isUnsavedMaintenanceRequest() {
+    return (
+      this.props.record?.resModel === "maintenance.request" &&
+      !this.state.thread.id
+    );
+  },
+
+  _confirmSaveBeforeChatterAction() {
+    return new Promise((resolve) => {
+      this.dialogService.add(ConfirmationDialog, {
+        title: _t("Spara ärendet först"),
+        body: _t(
+          "Ärendet är inte sparat ännu. Om du fortsätter skapas ärendet och ett SMS kan skickas till hyresgästen om att vi mottagit ärendet. Vill du spara ärendet nu?",
+        ),
+        confirm: () => resolve(true),
+        cancel: () => resolve(false),
+        confirmLabel: _t("Spara ärendet"),
+        cancelLabel: _t("Avbryt"),
+      });
+    });
+  },
+
+  async toggleComposer(mode = false, options = {}) {
+    if (mode && this._isUnsavedMaintenanceRequest()) {
+      const confirmed = await this._confirmSaveBeforeChatterAction();
+      if (!confirmed) {
+        return;
+      }
+    }
+    return super.toggleComposer(mode, options);
+  },
+
+  async scheduleActivity() {
+    if (this._isUnsavedMaintenanceRequest()) {
+      const confirmed = await this._confirmSaveBeforeChatterAction();
+      if (!confirmed) {
+        return;
+      }
+    }
+    return super.scheduleActivity();
+  },
+});


### PR DESCRIPTION
Users thought that an sms was sent to the tenant before the maintenance request was saved. After some investigating the issue was actually that the maintenance request was auto saved when interacting with the chatter component in odoo. "Skicka meddelande" or "Lägg till notering".

We agreed to implement a popup dialog that asks if the user wants to save the maintenance request or cancel instead of automatically saving when pressing these buttons. This gives the user a better sense of control of what is happening.