### PR TITLE
mim-1724: re-add menyanpassning action previously available in user settings

### DIFF
--- a/onecore_base_extension/views/res_users_view.xml
+++ b/onecore_base_extension/views/res_users_view.xml
@@ -13,4 +13,18 @@
         </field>
 
     </record>
+
+    <!-- Restore the Odoo 17 "Menyanpassning > Åtgärd" (Home Action) dropdown on the admin user form -->
+    <record id="view_users_form_action_id" model="ir.ui.view">
+        <field name="name">res.users.form.action.id</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form" />
+
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='preferences']//group[@name='other_preferences']"
+                position="inside">
+                <field name="action_id" string="Menyanpassning" />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
The dropdown was gone after updating to odoo 19. Re-added with this fix.