### PR TITLE
mim-1713: hide "blocked" indicator from maintenance request form

### DIFF
--- a/onecore_maintenance_extension/views/maintenance_views.xml
+++ b/onecore_maintenance_extension/views/maintenance_views.xml
@@ -108,6 +108,11 @@
                 <!-- Remove the Cancel button -->
                 <xpath expr="//header/button[1]" position="replace" />
 
+                <!-- Hide the kanban_state "blocked" indicator (MIM-1713) -->
+                <xpath expr="//field[@name='kanban_state']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+
                 <!-- Add a div before the first group tag -->
                 <xpath expr="//group[1]" position="before">
                     <div class="d-flex flex-nowrap align-items-center mb-3 border rounded"


### PR DESCRIPTION
Before:
<img width="1293" height="322" alt="Screenshot 2026-05-05 at 11 09 29" src="https://github.com/user-attachments/assets/cb4af6d0-be7a-4851-9944-cb7c133beb47" />

After:
<img width="1282" height="329" alt="Screenshot 2026-05-05 at 11 10 00" src="https://github.com/user-attachments/assets/8c390919-6c3c-4eb8-843b-132bd6f50a50" />
