### PR TITLE
bugfix: add _unaccent extension to fix åäö search issues

### DIFF
--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -56,6 +56,7 @@ class OneCoreMaintenanceRequest(
 ):
     _inherit = "maintenance.request"
     _order = "recently_added_tenant desc, request_date desc"
+    _unaccent = True
 
     # ============================================================================
     # CORE FIELDS

--- a/onecore_maintenance_extension/models/maintenance_building.py
+++ b/onecore_maintenance_extension/models/maintenance_building.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class OnecoreMaintenanceBuildingOption(models.Model):
     _name = "maintenance.building.option"
     _description = "building"
+    _unaccent = True
 
     building_id = fields.Char(string="Byggnads ID", store=True)
     name = fields.Char("Namn", required=True)
@@ -23,6 +24,7 @@ class OnecoreMaintenanceBuildingOption(models.Model):
 class OnecoreMaintenanceBuilding(models.Model):
     _name = "maintenance.building"
     _description = "Building"
+    _unaccent = True
 
     building_id = fields.Char(string="Byggnads ID", store=True)
     name = fields.Char("Namn", required=True)

--- a/onecore_maintenance_extension/models/maintenance_facility.py
+++ b/onecore_maintenance_extension/models/maintenance_facility.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class OnecoreMaintenanceFacilityOption(models.Model):
     _name = "maintenance.facility.option"
     _description = "Facility Option"
+    _unaccent = True
 
     user_id = fields.Many2one(
         "res.users", "Användare", default=lambda self: self.env.user
@@ -23,6 +24,7 @@ class OnecoreMaintenanceFacilityOption(models.Model):
 class OnecoreMaintenanceFacility(models.Model):
     _name = "maintenance.facility"
     _description = "Facility"
+    _unaccent = True
 
     rental_property_id = fields.Char(string="Hyresobjekt ID", store=True)
     name = fields.Char("Namn", required=True)

--- a/onecore_maintenance_extension/models/maintenance_lease.py
+++ b/onecore_maintenance_extension/models/maintenance_lease.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class OnecoreMaintenanceLeaseOption(models.Model):
     _name = "maintenance.lease.option"
     _description = "Lease Option"
+    _unaccent = True
 
     user_id = fields.Many2one("res.users", "User", default=lambda self: self.env.user)
     name = fields.Char("name", required=True)
@@ -35,6 +36,7 @@ class OnecoreMaintenanceLeaseOption(models.Model):
 class OnecoreMaintenanceLease(models.Model):
     _name = "maintenance.lease"
     _description = "Lease"
+    _unaccent = True
 
     name = fields.Char("name", required=True)
     lease_id = fields.Char(string="Kontrakt", store=True, readonly=True)

--- a/onecore_maintenance_extension/models/maintenance_maintenance_unit.py
+++ b/onecore_maintenance_extension/models/maintenance_maintenance_unit.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class OnecoreMaintenanceMaintenanceUnitOption(models.Model):
     _name = "maintenance.maintenance.unit.option"
     _description = "Maintenance Unit Option"
+    _unaccent = True
 
     name = fields.Char("name", required=True)
     type = fields.Char("Utrymmestyp")
@@ -24,6 +25,7 @@ class OnecoreMaintenanceMaintenanceUnitOption(models.Model):
 class OnecoreMaintenanceMaintenanceUnit(models.Model):
     _name = "maintenance.maintenance.unit"
     _description = "Maintenance Unit"
+    _unaccent = True
 
     name = fields.Char("name", required=True)
     type = fields.Char("Utrymmestyp")  # TODO vill vi nullable?

--- a/onecore_maintenance_extension/models/maintenance_parking_space.py
+++ b/onecore_maintenance_extension/models/maintenance_parking_space.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class OnecoreMaintenanceParkingSpaceOption(models.Model):
     _name = "maintenance.parking.space.option"
     _description = "Parking Space Option"
+    _unaccent = True
 
     user_id = fields.Many2one(
         "res.users", "Användare", default=lambda self: self.env.user
@@ -23,6 +24,7 @@ class OnecoreMaintenanceParkingSpaceOption(models.Model):
 class OnecoreMaintenanceParkingSpace(models.Model):
     _name = "maintenance.parking.space"
     _description = "Parking Space"
+    _unaccent = True
 
     rental_property_id = fields.Char(string="Hyresobjekt ID", store=True)
     name = fields.Char("Namn", required=True)

--- a/onecore_maintenance_extension/models/maintenance_property.py
+++ b/onecore_maintenance_extension/models/maintenance_property.py
@@ -5,6 +5,7 @@ class OnecoreMaintenancePropertyOption(models.Model):
     _name = "maintenance.property.option"
     _description = "Property"
     _rec_name = "designation"
+    _unaccent = True
 
     code = fields.Char("Kod", required=True)
     designation = fields.Char("Beteckning", required=True)
@@ -16,6 +17,7 @@ class OnecoreMaintenanceProperty(models.Model):
     _name = "maintenance.property"
     _description = "Property"
     _rec_name = "designation"
+    _unaccent = True
 
     code = fields.Char("Kod", required=True)
     designation = fields.Char("Beteckning", required=True)

--- a/onecore_maintenance_extension/models/maintenance_rental_property.py
+++ b/onecore_maintenance_extension/models/maintenance_rental_property.py
@@ -34,6 +34,7 @@ class OnecoreMaintenanceRentalPropertyOption(models.Model):
 class OnecoreMaintenanceRentalProperty(models.Model):
     _name = "maintenance.rental.property"
     _description = "Rental Property"
+    _unaccent = True
 
     rental_property_id = fields.Char(string="Hyresobjekt ID", store=True)
     name = fields.Char("Namn", required=True)

--- a/onecore_maintenance_extension/models/maintenance_rental_property.py
+++ b/onecore_maintenance_extension/models/maintenance_rental_property.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class OnecoreMaintenanceRentalPropertyOption(models.Model):
     _name = "maintenance.rental.property.option"
     _description = "Rental Property Option"
+    _unaccent = True
 
     user_id = fields.Many2one(
         "res.users", "Användare", default=lambda self: self.env.user

--- a/onecore_maintenance_extension/models/maintenance_staircase.py
+++ b/onecore_maintenance_extension/models/maintenance_staircase.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class OnecoreMaintenanceStaircaseOption(models.Model):
     _name = "maintenance.staircase.option"
     _description = "Staircase Option"
+    _unaccent = True
 
     # Core identification fields
     staircase_id = fields.Char(string="Trappuppgångs ID", store=True)
@@ -31,6 +32,7 @@ class OnecoreMaintenanceStaircaseOption(models.Model):
 class OnecoreMaintenanceStaircase(models.Model):
     _name = "maintenance.staircase"
     _description = "Staircase"
+    _unaccent = True
 
     # Core identification fields
     staircase_id = fields.Char(string="Trappuppgångs ID", store=True)

--- a/onecore_maintenance_extension/models/maintenance_tenant.py
+++ b/onecore_maintenance_extension/models/maintenance_tenant.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class OnecoreMaintenanceTenantOption(models.Model):
     _name = "maintenance.tenant.option"
     _description = "Tenant Option"
+    _unaccent = True
 
     user_id = fields.Many2one(
         "res.users", "Användare", default=lambda self: self.env.user
@@ -22,6 +23,7 @@ class OnecoreMaintenanceTenantOption(models.Model):
 class OnecoreMaintenanceTenant(models.Model):
     _name = "maintenance.tenant"
     _description = "Tenant"
+    _unaccent = True
 
     name = fields.Char("Namn", required=True)
     contact_code = fields.Char("Kundnummer", required=True)


### PR DESCRIPTION
This fix seems to make searches using åäö etc work better again (could recreate the issue in mim-1419 env).. however I think this might be the underlying issue. It requires a maintenance window though. Worth looking into!:

https://linear.app/mimer-onecore/issue/MIM-1761/prod-postgres-kors-med-lc-ctypec-byt-till-utf-8-locale