### PR TITLE
bugfix: import _t in mobile_renderer to fix Safari OwlError on mobile

### DIFF
--- a/onecore_ui/static/src/js/mobile_renderer.js
+++ b/onecore_ui/static/src/js/mobile_renderer.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 import { Component, useState, onMounted } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 import { View } from "@web/views/view";
 import { Field } from "@web/views/fields/field";
 import { isNull } from "@web/views/utils";


### PR DESCRIPTION
## Summary
Fixes OwlError ("Can't find variable: _t") on iOS Safari when opening the mobile Ärenden list / tapping "Ny". `mobile_renderer.js` calls `_t("None" | "Yes" | "No")` but never imports it — Safari raises ReferenceError immediately, aborting the Owl lifecycle.

Single-line fix: add `import { _t } from "@web/core/l10n/translation";`, matching how `mobile_view.js`, `mobile_group.js`, and `mobile_record.js` already import it.
