### PR TITLE
fix one-day offset in tracked-change log

### DIFF
--- a/onecore_maintenance_extension/models/services/maintenance_workflow_service.py
+++ b/onecore_maintenance_extension/models/services/maintenance_workflow_service.py
@@ -1,5 +1,7 @@
 """Service for managing maintenance request workflow, stages and field changes."""
 
+from datetime import datetime
+
 from odoo import _, exceptions, fields
 from markupsafe import Markup
 
@@ -160,7 +162,7 @@ class FieldChangeTracker:
         elif isinstance(field_obj, fields.Boolean):
             return self._format_boolean_change(old_value, new_value, field_label)
         elif isinstance(field_obj, (fields.Date, fields.Datetime)):
-            return self._format_date_change(old_value, new_value, field_label)
+            return self._format_date_change(field_obj, old_value, new_value, field_label)
         else:
             return self._format_generic_change(old_value, new_value, field_label)
 
@@ -204,22 +206,33 @@ class FieldChangeTracker:
         new_display = "Ja" if new_value else "Nej"
         return f"<strong>{field_label}:</strong> <span style='color: #999; text-decoration: line-through;'>{old_display}</span> → {new_display}"
 
-    def _format_date_change(self, old_value, new_value, field_label):
-        """Format Date/Datetime field change."""
-        old_display = old_value.strftime("%Y-%m-%d") if old_value else "Inte satt"
+    def _format_date_change(self, field_obj, old_value, new_value, field_label):
+        """Format Date/Datetime field change as YYYY-MM-DD in the user's timezone."""
+        is_datetime = isinstance(field_obj, fields.Datetime)
+        old_display = self._format_date_value(old_value, is_datetime)
+        new_display = self._format_date_value(new_value, is_datetime)
+        return (
+            f"<strong>{field_label}:</strong> "
+            f"<span style='color: #999; text-decoration: line-through;'>{old_display}</span> "
+            f"→ {new_display}"
+        )
 
-        if isinstance(new_value, str):
+    def _format_date_value(self, value, is_datetime):
+        if not value or value == "False":
+            return "Inte satt"
+        if isinstance(value, str):
             try:
-                new_date = (
-                    fields.Date.from_string(new_value) if new_value != "False" else None
+                value = (
+                    fields.Datetime.from_string(value)
+                    if is_datetime
+                    else fields.Date.from_string(value)
                 )
-                new_display = new_date.strftime("%Y-%m-%d") if new_date else "Inte satt"
-            except:
-                new_display = str(new_value) if new_value else "Inte satt"
-        else:
-            new_display = new_value.strftime("%Y-%m-%d") if new_value else "Inte satt"
-
-        return f"<strong>{field_label}:</strong> <span style='color: #999; text-decoration: line-through;'>{old_display}</span> → {new_display}"
+            except (ValueError, TypeError):
+                return str(value)
+        if is_datetime and isinstance(value, datetime):
+            # UTC -> user's timezone, so the logged date matches the form field
+            value = fields.Datetime.context_timestamp(self.env.user, value)
+        return value.strftime("%Y-%m-%d")
 
     def _format_generic_change(self, old_value, new_value, field_label):
         """Format generic field change."""

--- a/onecore_maintenance_extension/tests/models/services/test_maintenance_workflow_service.py
+++ b/onecore_maintenance_extension/tests/models/services/test_maintenance_workflow_service.py
@@ -1,7 +1,7 @@
 from odoo.tests.common import TransactionCase
 from odoo.tests import tagged
 from odoo.exceptions import UserError
-from datetime import date
+from datetime import date, datetime
 
 from ...utils.test_utils import create_internal_user, create_maintenance_request
 
@@ -293,6 +293,36 @@ class TestFieldChangeTracker(TransactionCase):
         )
         self.assertIn("2023-01-15", change)
         self.assertIn("invalid-date", change)
+
+    def test_datetime_field_change_uses_user_timezone(self):
+        """Datetime values must format in the user's local TZ, not UTC.
+
+        Regression: schedule_date showed UTC date in chatter while the form
+        showed the local date — a 1-day discrepancy near midnight CEST/CET
+        that confused tenants asking when contractors were planned to visit.
+        """
+        request = create_maintenance_request(self.env)
+        field_obj = request._fields["schedule_date"]
+
+        # CEST is UTC+2: 22:00 UTC = 00:00 next-day local
+        self.env.user.tz = "Europe/Stockholm"
+
+        # Setting from empty: 2026-05-06 22:00 UTC -> 2026-05-07 local
+        change = self.change_tracker._format_field_change(
+            field_obj, False, datetime(2026, 5, 6, 22, 0, 0), "Planerat utförandedatum"
+        )
+        self.assertIn("2026-05-07", change)
+        self.assertNotIn("2026-05-06", change)
+
+        # Both old and new converted: 12:00 UTC -> same-day local; 22:00 UTC -> next-day local
+        change = self.change_tracker._format_field_change(
+            field_obj,
+            datetime(2026, 5, 6, 12, 0, 0),
+            datetime(2026, 5, 7, 22, 0, 0),
+            "Planerat utförandedatum",
+        )
+        self.assertIn("2026-05-06", change)
+        self.assertIn("2026-05-08", change)
 
     def test_change_notification_posting(self):
         """Test that change notifications are properly posted as messages"""


### PR DESCRIPTION
Problem:
<img width="746" height="135" alt="image" src="https://github.com/user-attachments/assets/441d542b-cdf0-4a80-9946-f57b4c9e63f4" />


## Summary
- `_format_date_change` in `FieldChangeTracker` now converts UTC datetimes to the user's timezone before formatting, so the chatter date matches the form date for `schedule_date`, `closed_date`, and `performed_date`.
- Fixes one-day-earlier discrepancy reported on Planerat utförandedatum near midnight CEST/CET.

## Test plan
- [x] Regression test added: `test_datetime_field_change_uses_user_timezone`
- [x] Manually reproduced bug, applied fix, confirmed chatter date now matches form date for Scheduled Date changes


> **Note:** This does not retroactively fix existing chatter history, those messages remain as they were logged. The fix only prevents the bug from occurring on future changes.
