### PR TITLE
Feature/mim 1847 boolean for meddelanden mellan mimer och leverantor

### DIFF
--- a/onecore_mail_extension/models/mail_message.py
+++ b/onecore_mail_extension/models/mail_message.py
@@ -10,13 +10,27 @@ _logger = logging.getLogger(__name__)
 class OneCoreMailMessage(models.Model):
     _inherit = "mail.message"
 
+    informs_opposite_party = fields.Boolean(
+        string="Informera motparten",
+        default=False,
+        help="Loggnoteringar som markeras här visar dialogindikatorn (orange) "
+        "för motparten — Mimer ⇄ extern entreprenör.",
+    )
     is_dialog_unread_for_side = fields.Boolean(
         string="Okvitterad dialognotering",
         compute="_compute_is_dialog_unread_for_side",
         store=False,
     )
 
-    @api.depends("author_id", "date", "message_type", "subtype_id", "model", "res_id")
+    @api.depends(
+        "author_id",
+        "date",
+        "message_type",
+        "subtype_id",
+        "model",
+        "res_id",
+        "informs_opposite_party",
+    )
     def _compute_is_dialog_unread_for_side(self):
         # Highlights log notes from the opposite party (internal Mimer vs
         # external contractor) on maintenance.request until acknowledged via

--- a/onecore_mail_extension/static/src/tenant/tenant_composer.xml
+++ b/onecore_mail_extension/static/src/tenant/tenant_composer.xml
@@ -28,6 +28,14 @@
                     </CheckBox>
                 </div>
             </t>
+
+            <t t-if="showInformOpposite">
+                <div class="d-flex mb-3 mt-3">
+                    <CheckBox id="inform_opposite" value="tenantState.informOpposite" onChange.bind="onInformOppositeChange">
+                        <t t-out="informOppositeLabel"/>
+                    </CheckBox>
+                </div>
+            </t>
         </xpath>
 
     </t>

--- a/onecore_mail_extension/static/src/tenant/tenant_composer_patch.js
+++ b/onecore_mail_extension/static/src/tenant/tenant_composer_patch.js
@@ -17,6 +17,8 @@ patch(Composer.prototype, {
         this.tenantState = useState({
             sendSMS: false,
             sendEmail: false,
+            informOpposite: false,
+            userIsExternalContractor: false,
             tenantHasEmail: false,
             tenantHasPhoneNumber: false,
             isHiddenFromMyPages: false,
@@ -49,6 +51,15 @@ patch(Composer.prototype, {
             } catch (error) {
                 console.error("Error fetching tenant data:", error);
             }
+            try {
+                this.tenantState.userIsExternalContractor = await this.orm.call(
+                    "maintenance.request",
+                    "is_user_external_contractor",
+                    []
+                );
+            } catch (error) {
+                console.error("Error fetching external contractor state:", error);
+            }
         });
     },
 
@@ -57,6 +68,26 @@ patch(Composer.prototype, {
     },
     onEMailCheckboxChange(checked) {
         this.tenantState.sendEmail = checked;
+    },
+    onInformOppositeChange(checked) {
+        this.tenantState.informOpposite = checked;
+    },
+
+    // "Inform the opposite party" only applies to the internal Mimer <-> external
+    // contractor log-note dialog, so the checkbox is shown in Log note mode only.
+    get showInformOpposite() {
+        return (
+            this.props.type === "note" &&
+            this.thread?.model === "maintenance.request"
+        );
+    },
+
+    // Name the actual recipient side: a contractor informs Mimer, a Mimer
+    // handler informs the contractor.
+    get informOppositeLabel() {
+        return this.tenantState.userIsExternalContractor
+            ? "Informera Mimer"
+            : "Informera leverantör";
     },
 
     get placeholder() {
@@ -86,6 +117,7 @@ patch(Composer.prototype, {
         if (this.thread?.model === "maintenance.request") {
             data.sendSMS = this.tenantState.sendSMS;
             data.sendEmail = this.tenantState.sendEmail;
+            data.informOpposite = this.tenantState.informOpposite;
         }
         return data;
     },

--- a/onecore_mail_extension/static/src/tenant/tenant_store_service_patch.js
+++ b/onecore_mail_extension/static/src/tenant/tenant_store_service_patch.js
@@ -17,6 +17,9 @@ patch(Store.prototype, {
             }
             params.post_data.message_type = messageType;
         }
+        if (postData.informOpposite) {
+            params.post_data.informs_opposite_party = true;
+        }
         return params;
     },
 });

--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -377,6 +377,14 @@ class OneCoreMaintenanceRequest(
         # the key before it reaches message_post (see the mail.message field).
         return super()._get_allowed_message_params() | {"informs_opposite_party"}
 
+    def _get_message_create_valid_field_names(self):
+        # message_post() -> _message_create() validates the message values
+        # against this allow-list; our custom field must be added or posting a
+        # note with informs_opposite_party raises ValueError.
+        return super()._get_message_create_valid_field_names() | {
+            "informs_opposite_party"
+        }
+
     @api.model
     def _dialog_unread_message_ids(self, messages):
         """Return the ids of ``messages`` that are unread dialog notes for the

--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -324,6 +324,7 @@ class OneCoreMaintenanceRequest(
         "message_ids.author_id",
         "message_ids.message_type",
         "message_ids.subtype_id",
+        "message_ids.informs_opposite_party",
         "supplier_dialog_ack_at",
         "internal_dialog_ack_at",
     )
@@ -349,6 +350,7 @@ class OneCoreMaintenanceRequest(
                 ("message_type", "=", "comment"),
                 ("subtype_id", "=", note_subtype.id),
                 ("author_id", "!=", False),
+                ("informs_opposite_party", "=", True),
             ]
         )
         unread_ids = self._dialog_unread_message_ids(messages)
@@ -369,6 +371,12 @@ class OneCoreMaintenanceRequest(
             if record.id in unread_res_ids:
                 record[indicator_field] = True
 
+    def _get_allowed_message_params(self):
+        # Let the chatter composer flag a log note as "inform the opposite
+        # party" through /mail/message/post; without this the controller drops
+        # the key before it reaches message_post (see the mail.message field).
+        return super()._get_allowed_message_params() | {"informs_opposite_party"}
+
     @api.model
     def _dialog_unread_message_ids(self, messages):
         """Return the ids of ``messages`` that are unread dialog notes for the
@@ -376,21 +384,24 @@ class OneCoreMaintenanceRequest(
         contractors).
 
         A message counts when it is a log note (``mail.mt_note`` comment) on a
-        maintenance.request authored by the *opposite* side and posted after
-        that side last acknowledged the dialog. Acknowledgement is a single
-        per-side timestamp on the request, so one staffer marking it read
-        clears it for everyone on their side. The current user only selects
+        maintenance.request that its author flagged with
+        ``informs_opposite_party``, authored by the *opposite* side, and posted
+        after that side last acknowledged the dialog. Acknowledgement is a
+        single per-side timestamp on the request, so one staffer marking it
+        read clears it for everyone on their side. The current user only selects
         which side's view to compute; this is not per-user read state. Shared
         by ``_compute_dialog_indicators`` and
         ``mail.message._compute_is_dialog_unread_for_side`` so the rules live
         in exactly one place.
         """
-        # Cheap structural pre-filter before any ref lookups.
+        # Cheap structural pre-filter before any ref lookups. Only notes the
+        # author flagged "inform the opposite party" count.
         candidates = messages.filtered(
             lambda m: m.model == "maintenance.request"
             and m.message_type == "comment"
             and m.author_id
             and m.res_id
+            and m.informs_opposite_party
         )
         if not candidates:
             return set()

--- a/onecore_maintenance_extension/tests/models/test_dialog_indicator.py
+++ b/onecore_maintenance_extension/tests/models/test_dialog_indicator.py
@@ -20,11 +20,12 @@ class TestDialogIndicator(TransactionCase):
         self.external_user = create_external_contractor_user(self.env)
         self.request = create_maintenance_request(self.env)
 
-    def _post_log_note(self, user, body="hej"):
+    def _post_log_note(self, user, body="hej", inform=True):
         return self.request.with_user(user).message_post(
             body=body,
             message_type="comment",
             subtype_xmlid="mail.mt_note",
+            informs_opposite_party=inform,
         )
 
     def _refresh(self, user):
@@ -58,6 +59,23 @@ class TestDialogIndicator(TransactionCase):
         self._post_log_note(self.external_user)
         record = self._refresh(self.external_user)
         self.assertFalse(record.has_unread_internal_dialog)
+
+    def test_unflagged_note_does_not_trigger_chip(self):
+        # A log note posted without "inform the opposite party" must never
+        # surface the indicator, even to the opposite side.
+        self._post_log_note(self.external_user, inform=False)
+        record = self._refresh(self.internal_user)
+        self.assertFalse(record.has_unread_supplier_dialog)
+        self.assertFalse(record.has_unread_internal_dialog)
+
+    def test_inform_flag_is_an_allowed_message_param(self):
+        # The chatter composer sends informs_opposite_party through
+        # /mail/message/post, which only forwards keys in
+        # _get_allowed_message_params(). Lock that wiring here.
+        self.assertIn(
+            "informs_opposite_party",
+            self.request._get_allowed_message_params(),
+        )
 
     def test_acknowledge_clears_supplier_dialog_for_internal(self):
         self._post_log_note(self.external_user)
@@ -139,11 +157,12 @@ class TestMailMessageDialogUnread(TransactionCase):
         self.external_user = create_external_contractor_user(self.env)
         self.request = create_maintenance_request(self.env)
 
-    def _post_log_note(self, user, body="hej"):
+    def _post_log_note(self, user, body="hej", inform=True):
         return self.request.with_user(user).message_post(
             body=body,
             message_type="comment",
             subtype_xmlid="mail.mt_note",
+            informs_opposite_party=inform,
         )
 
     def test_internal_user_flags_supplier_log_note(self):
@@ -158,6 +177,11 @@ class TestMailMessageDialogUnread(TransactionCase):
 
     def test_own_log_note_is_not_flagged(self):
         msg = self._post_log_note(self.internal_user)
+        msg.invalidate_recordset(["is_dialog_unread_for_side"])
+        self.assertFalse(msg.with_user(self.internal_user).is_dialog_unread_for_side)
+
+    def test_unflagged_note_is_not_flagged(self):
+        msg = self._post_log_note(self.external_user, inform=False)
         msg.invalidate_recordset(["is_dialog_unread_for_side"])
         self.assertFalse(msg.with_user(self.internal_user).is_dialog_unread_for_side)
 


### PR DESCRIPTION
<img width="1112" height="176" alt="image" src="https://github.com/user-attachments/assets/32bf42b1-b8a5-4276-bb5c-8d22bc2300d2" />


Fick feedback om att lägga till en checkbox för när meddelanden ska gå mellan leverantör och mimer. Står "Informera Mimer" eller "Informera leverantör" beroende på vem som är inloggad. 