### PR TITLE
fix KeyError on nationalRegistrationNumber for company tenants

### DIFF
--- a/onecore_maintenance_extension/models/services/record_management_service.py
+++ b/onecore_maintenance_extension/models/services/record_management_service.py
@@ -343,9 +343,9 @@ class RecordManagementService:
                     "name": name,
                     "contact_code": tenant["contactCode"],
                     "contact_key": tenant["contactKey"],
-                    "national_registration_number": tenant[
+                    "national_registration_number": tenant.get(
                         "nationalRegistrationNumber"
-                    ],
+                    ),
                     "email_address": tenant.get("emailAddress"),
                     "phone_number": phone_number,
                     "is_tenant": tenant["isTenant"],


### PR DESCRIPTION
Problem
Opening certain maintenance requests failed with RPC_ERROR: Odoo Server Error and the record view never loaded — triggered just by clicking into the case.

Root cause
On open, Odoo recomputes the empty_tenant field, which calls _create_missing_lease_and_tenant → _create_tenant. That method read the personnummer with bracket access:


"national_registration_number": tenant["nationalRegistrationNumber"],
When the Core API returns a tenant without a nationalRegistrationNumber (e.g. a company/organization tenant, which has no personnummer), this raised KeyError: 'nationalRegistrationNumber', surfacing to the client as RPC_ERROR.

Fix
Use tenant.get("nationalRegistrationNumber") so a missing personnummer stores None instead of crashing. This matches the field's optional Char definition and the established pattern already used in base_handler.py.

Files changed
onecore_maintenance_extension/models/services/record_management_service.py