### PR TITLE
SMS from odoo gave contract status in "hello-message"

### DIFF
--- a/onecore_maintenance_extension/models/handlers/base_handler.py
+++ b/onecore_maintenance_extension/models/handlers/base_handler.py
@@ -101,21 +101,18 @@ class BaseMaintenanceHandler:
         return self.env["maintenance.lease.option"].create(lease_data)
 
     def _create_tenant_options(self, tenants, lease_option_id=None):
-        """Create tenant option records for a list of tenants."""
-        status_label = ""
-        if lease_option_id:
-            lease_record = self.env["maintenance.lease.option"].browse(lease_option_id)
-            if lease_record.exists():
-                status_label = LEASE_STATUS_LABELS.get(lease_record.lease_status, "")
+        """Create tenant option records for a list of tenants.
 
+        `name` holds the bare person name; the lease status is shown only in the
+        dropdown via the option's computed display_name (see maintenance_tenant).
+        """
         for tenant in tenants:
             name = get_tenant_name(tenant)
-            tenant_name = f"{name} ({status_label})" if status_label else name
             phone_number = get_main_phone_number(tenant)
 
             tenant_data = {
                 "user_id": self.env.user.id,
-                "name": tenant_name,
+                "name": name,
                 "contact_code": tenant["contactCode"],
                 "contact_key": tenant["contactKey"],
                 "national_registration_number": tenant.get(

--- a/onecore_maintenance_extension/models/maintenance_tenant.py
+++ b/onecore_maintenance_extension/models/maintenance_tenant.py
@@ -1,4 +1,6 @@
-from odoo import models, fields
+from odoo import api, models, fields
+
+from .constants import LEASE_STATUS_LABELS
 
 
 class OnecoreMaintenanceTenantOption(models.Model):
@@ -18,6 +20,24 @@ class OnecoreMaintenanceTenantOption(models.Model):
     is_tenant = fields.Boolean("Är hyresgäst", default=True)
     special_attention = fields.Boolean(string="Viktig kundinfo", readonly=True)
     lease_option_id = fields.Many2one("maintenance.lease.option", string="Lease Option")
+
+    @api.depends("name", "lease_option_id.lease_status")
+    def _compute_display_name(self):
+        """Show the lease status next to the name in the dropdown only.
+
+        `name` stays the bare person name (the value that gets persisted onto
+        the request and used in the SMS); the status label (e.g. "Gällande") is
+        purely presentational so users can tell apart a person's several leases.
+        """
+        for option in self:
+            status_label = (
+                LEASE_STATUS_LABELS.get(option.lease_option_id.lease_status)
+                if option.lease_option_id
+                else None
+            )
+            option.display_name = (
+                f"{option.name} ({status_label})" if status_label else option.name
+            )
 
 
 class OnecoreMaintenanceTenant(models.Model):

--- a/onecore_maintenance_extension/models/services/form_field_service.py
+++ b/onecore_maintenance_extension/models/services/form_field_service.py
@@ -90,6 +90,8 @@ class FormFieldService:
 
     def _copy_tenant_fields(self, record):
         """Copy tenant data fields from tenant_option_id to the record."""
+        # `name` is the bare person name; the lease-status label lives only in
+        # the option's display_name, so it never leaks into the record or SMS.
         record.tenant_id = record.tenant_option_id.name
         record.tenant_name = record.tenant_option_id.name
         record.contact_code = record.tenant_option_id.contact_code

--- a/onecore_maintenance_extension/tests/models/handlers/test_base_handler.py
+++ b/onecore_maintenance_extension/tests/models/handlers/test_base_handler.py
@@ -430,6 +430,37 @@ class TestBaseMaintenanceHandler(TransactionCase):
         )
         self.assertEqual(tenant_option.lease_option_id.id, lease_option.id)
 
+    def test_create_tenant_options_status_label_only_in_display_name(self):
+        """`name` stays the bare person name; status shows only in display_name."""
+        rental_property_option = create_rental_property_option(self.env)
+        lease_option = create_lease_option(
+            self.env,
+            rental_property_option_id=rental_property_option.id,
+            lease_status=0,  # 0 -> "Gällande"
+        )
+
+        first_name = self.fake.first_name()
+        last_name = self.fake.last_name()
+        tenants = [
+            {
+                "contactCode": self.fake.contact_code(),
+                "contactKey": self.fake.contact_key(),
+                "firstName": first_name,
+                "lastName": last_name,
+                "phoneNumbers": [],
+                "isTenant": True,
+            }
+        ]
+
+        self.handler._create_tenant_options(tenants, lease_option_id=lease_option.id)
+
+        tenant_option = self.env["maintenance.tenant.option"].search(
+            [("contact_code", "=", tenants[0]["contactCode"])]
+        )
+        bare_name = f"{first_name} {last_name}"
+        self.assertEqual(tenant_option.name, bare_name)
+        self.assertEqual(tenant_option.display_name, f"{bare_name} (Gällande)")
+
     def test_create_tenant_options_without_lease_option(self):
         """Test that tenant options have no lease link when none is provided."""
         tenants = [

--- a/onecore_maintenance_extension/tests/models/services/test_record_management_service.py
+++ b/onecore_maintenance_extension/tests/models/services/test_record_management_service.py
@@ -8,6 +8,7 @@ from ...utils.test_utils import (
     create_building_option,
     create_rental_property_option,
     create_tenant_option,
+    create_lease_option,
 )
 
 
@@ -70,6 +71,23 @@ class TestRecordManagementService(TransactionCase):
         self.assertEqual(request.tenant_id.name, tenant_option.name)
         self.assertEqual(request.tenant_id.contact_code, tenant_option.contact_code)
         self.assertEqual(request.tenant_id.phone_number, tenant_option.phone_number)
+
+    def test_save_tenant_option_persists_name_without_status_label(self):
+        """The lease-status label is a dropdown-only decoration on display_name,
+        so the persisted tenant name and SMS source stay free of it."""
+        lease_option = create_lease_option(self.env, lease_status=0)  # "Gällande"
+        tenant_option = create_tenant_option(
+            self.env, name="David Lindblom", lease_option_id=lease_option.id
+        )
+        # The dropdown shows the status, but the stored name does not.
+        self.assertEqual(tenant_option.display_name, "David Lindblom (Gällande)")
+
+        request = create_maintenance_request(
+            self.env, tenant_option_id=tenant_option.id, hidden_from_my_pages=True
+        )
+
+        self.assertEqual(request.tenant_id.name, "David Lindblom")
+        self.assertEqual(request.tenant_name, "David Lindblom")
 
     def test_save_tenant_uses_form_phone_email_over_option_values(self):
         """When creating with modified phone/email in form, should use form values over option values"""


### PR DESCRIPTION
The creation SMS read "Hej David Lindblom (Gällande)!" — the "(Gällande)"
is a lease-status label, not part of the name. _create_tenant_options
baked the status into the tenant option's `name` (f"{name} ({status})")
to disambiguate a person's multiple leases in the dropdown, but
_copy_tenant_fields then copied that decorated string verbatim into the
persisted tenant_id/tenant_name, which _send_creation_sms reads — so the
label leaked into stored data and the text message.

Keep `name` as the bare person name and move the status decoration to the
tenant option's computed display_name, which is what the Many2one dropdown
renders. The label is now purely presentational and derived live from
lease_option_id.lease_status, so the dropdown still shows "Name (Gällande)"
while the saved "Hyresgäst" field and the SMS show just "Name". The copy
logic reads the clean `name` with no change to _send_creation_sms.

Scope is tenant-only: the lease option uses the same pattern, but its name
surfaces in the visible "Kontrakt" field (no SMS), where showing the
contract status is intentional, so it is left unchanged.