### PR TITLE
fix maintenance form crash (KeyError) when assignee is not in the team

### DIFF
--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -501,9 +501,6 @@ class OneCoreMaintenanceRequest(
             if record.maintenance_team_id:
                 ids = record.maintenance_team_id.member_ids.ids
                 record.maintenance_team_domain = [("id", "in", ids)]
-
-                if record.user_id.id not in ids:
-                    record.user_id = False
             else:
                 record.maintenance_team_domain = []
 
@@ -729,6 +726,18 @@ class OneCoreMaintenanceRequest(
             )
             if "stage_id" in updates:
                 record.stage_id = updates["stage_id"]
+
+    @api.onchange("maintenance_team_id")
+    def _onchange_maintenance_team_id(self):
+        # Clear an assignee who is not a member of the newly selected team.
+        # This is UI-only: it must never run from a compute (i.e. on read),
+        # since user_id is stored and writing it would mutate the record and
+        # break web_read. See _compute_maintenance_team_domain.
+        for record in self:
+            if record.maintenance_team_id and record.user_id:
+                member_ids = record.maintenance_team_id.member_ids.ids
+                if record.user_id.id not in member_ids:
+                    record.user_id = False
 
     # ============================================================================
     # CRUD OPERATIONS


### PR DESCRIPTION
Opening certain maintenance requests 500s with RPC_ERROR → KeyError and the form never loads.

Cause: _compute_maintenance_team_domain runs on read and wrote to the record (cleared user_id when the assignee wasn't a team member), which also reset stage_id — so values changed mid-web_read and the many2one lookup failed. A compute must never write on read.

Fix: compute now only builds the domain; the clear-out-of-team-assignee logic moved to @api.onchange("maintenance_team_id") (UI-only).

CARD: https://linear.app/mimer-onecore/issue/MIM-1864/maintenance-requests-crash-when-assignee-isnt-in-team