### PR TITLE
MIM-1867 Odoo: "har du ändrat någon fastighetskomponent?" flow when ärende is marked Utförd

### DIFF
--- a/onecore_api/core_api.py
+++ b/onecore_api/core_api.py
@@ -3,7 +3,16 @@ import logging
 import urllib.parse
 import json
 
+from concurrent.futures import ThreadPoolExecutor
+
 _logger = logging.getLogger(__name__)
+
+# Cap on concurrent outbound HTTP calls to OneCore when fanning out (e.g.
+# fetching components for every room of an apartment).
+_PARALLEL_GET_MAX_WORKERS = 8
+# (connect, read) timeout for each parallel call — without it a single hung
+# OneCore call would block its worker thread and stall the whole wave.
+_PARALLEL_GET_TIMEOUT = (5, 30)
 
 
 class CoreApi:
@@ -60,6 +69,69 @@ class CoreApi:
         response = self.request("GET", url, **kwargs)
         response.raise_for_status()
         return response.json().get("content")
+
+    def parallel_get_json(self, urls):
+        """Fetch several GET endpoints concurrently and return their ``content``.
+
+        Pure outbound HTTP: the auth token and base URL are read ONCE here on
+        the calling (main) thread, then each request runs in a worker thread
+        that only touches the captured strings + ``requests`` — never
+        ``self.env``/the ORM (not thread-safe).
+
+        Args:
+            urls: list of path strings (same form as ``_get_json``).
+
+        Returns:
+            list aligned with ``urls``; each item is the parsed ``content`` on
+            success or ``None`` on any error (logged). Falls back to serial
+            ``_get_json`` if the prerequisites for threading aren't met.
+        """
+        if not urls:
+            return []
+
+        token = self._get_persisted_token()
+        base_url = self._get_env_value("onecore_base_url")
+
+        # Without a token/base_url we can't do the pure-HTTP threaded path;
+        # fall back to the serial (ORM-aware, token-refreshing) client.
+        if not token or not base_url:
+            return self._serial_get_json_safe(urls)
+
+        headers = {"Authorization": f"Bearer {token}"}
+
+        def _fetch(path):
+            # Runs in a worker thread — no self.env access here.
+            try:
+                response = requests.get(
+                    f"{base_url}{path}",
+                    headers=headers,
+                    timeout=_PARALLEL_GET_TIMEOUT,
+                )
+                response.raise_for_status()
+                return response.json().get("content")
+            except Exception as err:
+                _logger.warning("parallel_get_json failed for %s: %s", path, err)
+                return None
+
+        try:
+            max_workers = min(_PARALLEL_GET_MAX_WORKERS, len(urls))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                # executor.map preserves input order.
+                return list(executor.map(_fetch, urls))
+        except Exception as err:
+            _logger.warning("parallel_get_json pool failed, falling back to serial: %s", err)
+            return self._serial_get_json_safe(urls)
+
+    def _serial_get_json_safe(self, urls):
+        """Serial fallback for parallel_get_json: same shape (None on error)."""
+        results = []
+        for url in urls:
+            try:
+                results.append(self._get_json(url))
+            except Exception as err:
+                _logger.warning("parallel_get_json (serial) failed for %s: %s", url, err)
+                results.append(None)
+        return results
 
     def fetch_leases(self, identifier, value, location_type):
         paths = {

--- a/onecore_api/tests/test_core_api.py
+++ b/onecore_api/tests/test_core_api.py
@@ -780,3 +780,55 @@ class TestFetchFormData:
             api.fetch_form_data("leaseId", "123", "Bostad")
 
         assert str(exc_info.value) == "Test error"
+
+
+class TestParallelGetJson:
+    """Tests for parallel_get_json (concurrent OneCore fan-out)."""
+
+    def _resp(self, content):
+        r = Mock()
+        r.json.return_value = {"content": content}
+        r.raise_for_status.return_value = None
+        return r
+
+    def test_empty_urls_returns_empty(self, api):
+        """No URLs -> no work, empty list."""
+        assert api.parallel_get_json([]) == []
+
+    def test_returns_results_in_input_order(self, api):
+        """Results align with the input path order."""
+        with patch('core_api.requests.get') as mock_get:
+            mock_get.side_effect = lambda url, **kwargs: self._resp(url)
+            result = api.parallel_get_json(["/a", "/b", "/c"])
+
+        # base_url from mock_env fixture is https://api.example.com
+        assert result == [
+            "https://api.example.com/a",
+            "https://api.example.com/b",
+            "https://api.example.com/c",
+        ]
+
+    def test_per_path_error_becomes_none(self, api):
+        """A failing path yields None without failing the batch."""
+        def _side_effect(url, **kwargs):
+            if url.endswith("/bad"):
+                raise requests.HTTPError("500")
+            return self._resp("ok")
+
+        with patch('core_api.requests.get', side_effect=_side_effect):
+            result = api.parallel_get_json(["/good", "/bad"])
+
+        assert result == ["ok", None]
+
+    def test_falls_back_to_serial_without_token(self, mock_env):
+        """With no token, uses the serial _get_json path."""
+        with patch('core_api.CoreApi._get_auth_token'):
+            api = CoreApi(mock_env)
+        # Drop the token so the threaded precondition fails
+        mock_env["ir.config_parameter"].sudo().set_param("onecore_api_token", None)
+
+        with patch.object(api, '_get_json', side_effect=lambda url: f"serial:{url}") as mock_serial:
+            result = api.parallel_get_json(["/x", "/y"])
+
+        assert result == ["serial:/x", "serial:/y"]
+        assert mock_serial.call_count == 2

--- a/onecore_maintenance_extension/models/maintenance.py
+++ b/onecore_maintenance_extension/models/maintenance.py
@@ -1105,4 +1105,5 @@ class OneCoreMaintenanceRequest(
             "view_type": "form",
             "views": [(False, "form")],
             "target": "new",
+            "context": {"dialog_size": "extra-large"},
         }

--- a/onecore_maintenance_extension/models/maintenance_component_line.py
+++ b/onecore_maintenance_extension/models/maintenance_component_line.py
@@ -27,7 +27,10 @@ class MaintenanceComponentLine(models.TransientModel):
         ondelete="cascade",
     )
 
-    # All image URLs from OneCore as JSON array
+    # All image URLs from OneCore as JSON array. Left empty at wizard load —
+    # the image_gallery widget fetches a component's URLs on demand via
+    # get_component_image_urls() only when that component's detail is opened.
+    # (Loading every component's documents at load dominated the load time.)
     image_urls_json = fields.Text(string="Bild-URLer (JSON)", default='[]')
 
     # Computed field to check if there are any images
@@ -106,6 +109,30 @@ class MaintenanceComponentLine(models.TransientModel):
                 economic_lifespan_months=record.economic_lifespan,
                 installation_date=record.installation_date,
             )
+
+    @api.model
+    def get_component_image_urls(self, line_id):
+        """Fetch image URLs for a single component on demand.
+
+        Called by the image_gallery widget when a component's detail form is
+        opened, so the documents-call happens once for the viewed component
+        instead of for every component at wizard load.
+        """
+        line = self.browse(line_id)
+        if not line.exists() or not line.onecore_component_id:
+            return []
+        try:
+            urls = ComponentOneCoreService(self.env).fetch_all_component_image_urls(
+                line.onecore_component_id
+            )
+            return urls or []
+        except Exception as e:
+            _logger.warning(
+                "Failed to fetch image URLs for component %s: %s",
+                line.onecore_component_id,
+                e,
+            )
+            return []
 
     @api.depends('image_urls_json')
     def _compute_has_images(self):

--- a/onecore_maintenance_extension/models/maintenance_component_wizard.py
+++ b/onecore_maintenance_extension/models/maintenance_component_wizard.py
@@ -463,10 +463,16 @@ class MaintenanceComponentWizard(models.TransientModel):
         self.available_rooms_json = rooms_json
         self.available_categories_json = categories_json
 
-        ComponentLine = self.env['maintenance.component.line']
+        line_vals = []
         for comp_data in component_data_list:
             comp_data['wizard_id'] = self.id
-            ComponentLine.create(comp_data)
+            # image_urls_json is left empty at load (the gallery widget
+            # fetches it lazily) — drop it if a caller still provides it
+            comp_data.pop('image_urls_json', None)
+            line_vals.append(comp_data)
+        if line_vals:
+            # Single batched create instead of one insert per component
+            self.env['maintenance.component.line'].create(line_vals)
 
     @api.model
     def search_component_models(self, search_text, type_id=None, subtype_id=None):

--- a/onecore_maintenance_extension/models/services/component_onecore_service.py
+++ b/onecore_maintenance_extension/models/services/component_onecore_service.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import urllib.parse
 from datetime import datetime
 
 from odoo import fields
@@ -125,7 +126,8 @@ class ComponentOneCoreService:
             return '[]', '[]', []
 
         try:
-            # Fetch rooms directly by rental id
+            # Fetch rooms first (serial): primes/refreshes the auth token so
+            # the parallel wave below runs with a valid token.
             rooms = self.api.fetch_rooms(rental_property_id)
             if not rooms:
                 return '[]', '[]', []
@@ -136,23 +138,28 @@ class ComponentOneCoreService:
                 for r in rooms
             ])
 
-            # Fetch categories
-            categories_json = '[]'
-            try:
-                categories = self.api.fetch_component_categories()
-                if categories:
-                    categories_json = json.dumps(categories)
-            except Exception as e:
-                _logger.warning(f"Failed to fetch component categories: {e}")
+            # Fan out concurrently: component categories + components for every
+            # room in a single parallel wave (was a serial call per room, which
+            # dominated the wizard's load time).
+            categories_path = "/component-categories"
+            room_paths = [
+                "/components/by-room/%s"
+                % urllib.parse.quote(str(room.get('propertyObjectId')), safe='')
+                for room in rooms
+            ]
+            results = self.api.parallel_get_json([categories_path] + room_paths)
 
-            # Fetch components for each room
+            categories = results[0]
+            categories_json = json.dumps(categories) if categories else '[]'
+
+            # Transform components (main thread — pure dict work, no HTTP/ORM).
+            # Image URLs are intentionally NOT loaded here; the wizard loads a
+            # component's images lazily when its detail is opened.
             component_data_list = []
-            for room in rooms:
-                room_id = room.get('propertyObjectId')
+            for room, room_components in zip(rooms, results[1:]):
                 room_name = room.get('name', 'Okänt rum')
-
-                room_components = self._fetch_room_components(room_id)
-                for comp in room_components:
+                room_id = room.get('propertyObjectId')
+                for comp in room_components or []:
                     comp_data = self._transform_component_data(comp, room_name, room_id)
                     if comp_data:
                         component_data_list.append(comp_data)
@@ -162,22 +169,6 @@ class ComponentOneCoreService:
         except Exception as e:
             _logger.warning(f"Failed to fetch components from OneCore: {e}")
             return '[]', '[]', []
-
-    def _fetch_room_components(self, room_id):
-        """Fetch components for a specific room.
-
-        Args:
-            room_id: The room/property object ID
-
-        Returns:
-            list: List of component dicts from API
-        """
-        try:
-            components = self.api.fetch_components_by_room(room_id)
-            return components or []
-        except Exception as e:
-            _logger.warning(f"Failed to fetch components for room {room_id}: {e}")
-            return []
 
     def _transform_component_data(self, comp, room_name, room_id):
         """Transform OneCore component data to wizard format.
@@ -211,9 +202,10 @@ class ComponentOneCoreService:
                 install_date = install_date_str[:10]  # Extract YYYY-MM-DD
             installation_id = installations[0].get('id')
 
-        # Fetch all image URLs for the component (not base64 data)
-        image_urls = self.fetch_all_component_image_urls(comp.get('id'))
-
+        # NOTE: image URLs are intentionally NOT fetched here — that used to
+        # cost one documents-call per component and dominated the wizard's
+        # load time. maintenance.component.line fetches them lazily via the
+        # image_urls_json compute when a component's detail form is opened.
         return {
             'typ': component_type_data.get('typeName'),
             'subtype': subtype_data.get('subTypeName'),
@@ -238,8 +230,6 @@ class ComponentOneCoreService:
             'economic_lifespan': comp.get('economicLifespan') or 0,
             'technical_lifespan': subtype_data.get('technicalLifespan') or 0,
             'replacement_interval': subtype_data.get('replacementIntervalMonths') or 0,
-            # All image URLs from OneCore as JSON array
-            'image_urls_json': json.dumps(image_urls) if image_urls else '[]',
         }
 
     def search_models(self, search_text, type_id=None, subtype_id=None):

--- a/onecore_maintenance_extension/static/src/js/image_gallery.js
+++ b/onecore_maintenance_extension/static/src/js/image_gallery.js
@@ -2,6 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { useService } from "@web/core/utils/hooks";
 import { Component, useState, useEffect } from "@odoo/owl";
 
 /**
@@ -17,10 +18,54 @@ export class ImageGallery extends Component {
     };
 
     setup() {
+        this.orm = useService("orm");
         this.state = useState({
             isFullscreen: false,
             fullscreenIndex: 0,
+            // Lazily-fetched URLs (null until loaded). When set, takes
+            // precedence over the bound field value.
+            lazyUrls: null,
+            loading: false,
+            // resId we've already fetched for — guards against refetching on
+            // every re-render / dependency tick.
+            lastFetchedId: null,
         });
+
+        // Lazy image load: the wizard leaves image_urls_json empty at load to
+        // avoid a documents-call per component. When this gallery is shown for
+        // a component (its detail form opened) and the field is empty, fetch
+        // just this component's URLs. useEffect (not onWillStart) so it runs
+        // AFTER mount once the dialog record is populated, and re-runs if the
+        // bound record changes.
+        useEffect(
+            (resId, componentId) => {
+                const fieldEmpty = !this._parseUrls(
+                    this.props.record.data[this.props.name]
+                ).length;
+                if (
+                    fieldEmpty &&
+                    componentId &&
+                    resId &&
+                    this.state.lastFetchedId !== resId
+                ) {
+                    this.state.lastFetchedId = resId;
+                    this.state.loading = true;
+                    this.orm
+                        .call(this.props.record.resModel, "get_component_image_urls", [resId])
+                        .then((urls) => {
+                            this.state.lazyUrls = Array.isArray(urls) ? urls : [];
+                        })
+                        .catch((e) => {
+                            console.warn("Failed to load component images", e);
+                            this.state.lazyUrls = [];
+                        })
+                        .finally(() => {
+                            this.state.loading = false;
+                        });
+                }
+            },
+            () => [this.props.record.resId, this.props.record.data.onecore_component_id]
+        );
 
         // Handle escape key to close fullscreen
         useEffect(
@@ -63,12 +108,24 @@ export class ImageGallery extends Component {
      * @returns {string[]} Array of image URLs
      */
     get imageUrls() {
-        const value = this.props.record.data[this.props.name];
-        if (!value) return [];
+        // Lazily-fetched URLs (when the field was left empty at load) take
+        // precedence over the stored field value.
+        if (this.state.lazyUrls !== null) {
+            return this.state.lazyUrls.filter((url) => url);
+        }
+        return this._parseUrls(this.props.record.data[this.props.name]);
+    }
 
+    /**
+     * Parses a JSON-array field value into a clean list of URLs.
+     * @param {string} value
+     * @returns {string[]}
+     */
+    _parseUrls(value) {
+        if (!value) return [];
         try {
             const urls = JSON.parse(value);
-            return Array.isArray(urls) ? urls.filter(url => url) : [];
+            return Array.isArray(urls) ? urls.filter((url) => url) : [];
         } catch (e) {
             return [];
         }

--- a/onecore_maintenance_extension/static/src/views/image_gallery.xml
+++ b/onecore_maintenance_extension/static/src/views/image_gallery.xml
@@ -3,8 +3,16 @@
 
     <t t-name="onecore_maintenance_extension.ImageGallery">
         <div class="image-gallery-container">
+            <!-- Lazy-load spinner while fetching this component's images -->
+            <t t-if="state.loading">
+                <div class="text-muted text-center p-3">
+                    <i class="fa fa-circle-o-notch fa-spin fa-2x mb-2 d-block"/>
+                    <span>Laddar bilder…</span>
+                </div>
+            </t>
+
             <!-- 3-column responsive grid for thumbnails -->
-            <t t-if="hasImages">
+            <t t-elif="hasImages">
                 <div class="row g-2">
                     <t t-foreach="imageUrls" t-as="url" t-key="url_index">
                         <div class="col-4">

--- a/onecore_maintenance_extension/tests/models/services/test_component_onecore_service.py
+++ b/onecore_maintenance_extension/tests/models/services/test_component_onecore_service.py
@@ -120,9 +120,6 @@ class TestComponentOneCoreService(TransactionCase):
         ]
 
         cat_id = self.fake.component_category_id()
-        self.mock_api.fetch_component_categories.return_value = [
-            {'id': cat_id, 'categoryName': 'Kök'}
-        ]
 
         component = {
             'id': self.fake.component_instance_id(),
@@ -145,8 +142,13 @@ class TestComponentOneCoreService(TransactionCase):
                 }
             ]
         }
-        self.mock_api.fetch_components_by_room.return_value = [component]
-        self.mock_api.fetch_component_documents.return_value = []
+        # Categories + per-room components are fetched in one parallel wave;
+        # results are aligned: [categories, room1_components, room2_components]
+        self.mock_api.parallel_get_json.return_value = [
+            [{'id': cat_id, 'categoryName': 'Kök'}],
+            [component],
+            [component],
+        ]
 
         rooms_json, categories_json, components = service.load_components_for_residence(
             'rental-prop-123', 'Lägenhet'
@@ -162,6 +164,13 @@ class TestComponentOneCoreService(TransactionCase):
         self.assertEqual(len(components), 2)
         self.assertEqual(components[0]['model'], model_name)
         self.assertEqual(components[0]['serial_number'], serial)
+
+        # Components are loaded via the parallel helper, not per-room serial
+        # calls, and image URLs are NOT fetched during load (deferred to the
+        # gallery widget) — both used to dominate the wizard's load time.
+        self.mock_api.parallel_get_json.assert_called_once()
+        self.mock_api.fetch_component_documents.assert_not_called()
+        self.assertNotIn('image_urls_json', components[0])
 
     def test_onecore_load_components_non_apartment(self):
         """Returns empty for non-apartment space_caption."""

--- a/onecore_maintenance_extension/tests/models/test_maintenance_component_line.py
+++ b/onecore_maintenance_extension/tests/models/test_maintenance_component_line.py
@@ -60,14 +60,55 @@ class TestComponentLineComputedFields(TransactionCase):
         )
         self.assertFalse(line.has_images)
 
-    def test_has_images_false_with_none(self):
-        """has_images is False when image_urls_json is falsy."""
-        line = create_component_line(
-            self.env,
-            self.wizard.id,
-            image_urls_json=False,
-        )
+    def test_image_urls_json_empty_at_load(self):
+        """image_urls_json defaults empty — images are loaded on demand."""
+        line = create_component_line(self.env, self.wizard.id)
+        self.assertEqual(line.image_urls_json or '[]', '[]')
         self.assertFalse(line.has_images)
+
+    def test_get_component_image_urls_fetches_for_one_component(self):
+        """get_component_image_urls returns URLs for the given line only."""
+        line = create_component_line(self.env, self.wizard.id)
+        urls = ['https://example.com/a.jpg', 'https://example.com/b.jpg']
+
+        with patch(f'{LINE_PATH}.ComponentOneCoreService') as MockService:
+            MockService.return_value.fetch_all_component_image_urls.return_value = urls
+            result = self.env['maintenance.component.line'].get_component_image_urls(
+                line.id
+            )
+
+        self.assertEqual(result, urls)
+        MockService.return_value.fetch_all_component_image_urls.assert_called_once_with(
+            line.onecore_component_id
+        )
+
+    def test_get_component_image_urls_without_component_id(self):
+        """Returns [] (no fetch) when the line has no OneCore id."""
+        line = create_component_line(
+            self.env, self.wizard.id, onecore_component_id=False
+        )
+
+        with patch(f'{LINE_PATH}.ComponentOneCoreService') as MockService:
+            result = self.env['maintenance.component.line'].get_component_image_urls(
+                line.id
+            )
+
+        self.assertEqual(result, [])
+        MockService.return_value.fetch_all_component_image_urls.assert_not_called()
+
+    def test_get_component_image_urls_on_error(self):
+        """Returns [] when the image fetch raises."""
+        line = create_component_line(self.env, self.wizard.id)
+
+        with patch(f'{LINE_PATH}.ComponentOneCoreService') as MockService:
+            MockService.return_value.fetch_all_component_image_urls.side_effect = (
+                Exception("API error")
+            )
+            result = self.env['maintenance.component.line'].get_component_image_urls(
+                line.id
+            )
+
+        self.assertEqual(result, [])
 
     def test_current_value_with_depreciation(self):
         """current_value computed via linear depreciation."""

--- a/onecore_maintenance_extension/tests/utils/fake_providers.py
+++ b/onecore_maintenance_extension/tests/utils/fake_providers.py
@@ -536,7 +536,6 @@ class ComponentProvider(BaseProvider):
             'economic_lifespan': self.component_lifespan_months(),
             'technical_lifespan': self.component_lifespan_months(),
             'replacement_interval': self.component_replacement_interval(),
-            'image_urls_json': '[]',
         }
         data.update(overrides)
         return data

--- a/onecore_maintenance_extension/views/maintenance_component_wizard_view.xml
+++ b/onecore_maintenance_extension/views/maintenance_component_wizard_view.xml
@@ -75,9 +75,13 @@
                                         <!-- Images section -->
                                         <separator string="Bilder"/>
 
-                                        <!-- Existing images from OneCore (read-only gallery with fullscreen) -->
-                                        <field name="has_images" invisible="1"/>
-                                        <div invisible="not has_images" class="mb-3">
+                                        <!-- Existing images from OneCore (read-only gallery with
+                                             fullscreen). Gated on the component id, NOT has_images:
+                                             image_urls_json is left empty at load and the gallery
+                                             widget fetches this component's URLs lazily on mount —
+                                             a has_images gate would keep the widget unmounted and
+                                             the lazy load would never fire. -->
+                                        <div invisible="not onecore_component_id" class="mb-3">
                                             <div class="o_form_label mb-2">Befintliga bilder</div>
                                             <field name="image_urls_json" widget="image_gallery" readonly="1" nolabel="1"/>
                                         </div>

--- a/onecore_web_extension/static/src/js/component_question_dialog.js
+++ b/onecore_web_extension/static/src/js/component_question_dialog.js
@@ -1,0 +1,67 @@
+/** @odoo-module **/
+
+import { Component } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { _t } from "@web/core/l10n/translation";
+
+/**
+ * Three-outcome dialog asked when an internal user sets a maintenance
+ * request to "Utförd" on an apartment ärende: has a property component been
+ * replaced?
+ *
+ * Custom component (not ConfirmationDialog) so that Ja/Nej are explicit
+ * labeled buttons while dismiss (X/Esc) is a distinct third outcome that
+ * aborts the stage change.
+ */
+export class ComponentQuestionDialog extends Component {
+  static template = "onecore_web_extension.ComponentQuestionDialog";
+  static components = { Dialog };
+  static props = {
+    close: Function, // injected by the dialog service
+    answer: Function, // callback("yes" | "no")
+  };
+
+  _answer(value) {
+    this.props.answer(value);
+    this.props.close();
+  }
+
+  onYes() {
+    this._answer("yes");
+  }
+
+  onNo() {
+    this._answer("no");
+  }
+}
+
+/**
+ * Shows the component question and resolves with the user's answer.
+ *
+ * - "yes": proceed with the stage change and open the component wizard
+ * - "no": proceed with the stage change only
+ * - "abort": cancel the stage change (X or Esc without answering)
+ *
+ * @param {Object} dialogService - the "dialog" service
+ * @returns {Promise<"yes"|"no"|"abort">}
+ */
+export function askComponentQuestion(dialogService) {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const answer = (value) => {
+      if (!resolved) {
+        resolved = true;
+        resolve(value);
+      }
+    };
+
+    dialogService.add(
+      ComponentQuestionDialog,
+      { answer },
+      {
+        // X / Esc without picking a button → abort the stage change
+        onClose: () => answer("abort"),
+      }
+    );
+  });
+}

--- a/onecore_web_extension/static/src/js/kanban_record_patch.js
+++ b/onecore_web_extension/static/src/js/kanban_record_patch.js
@@ -7,6 +7,17 @@ import { KanbanRecord } from "@web/views/kanban/kanban_record";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import ConfirmDialog from "./confirm_dialog";
+import { askComponentQuestion } from "./component_question_dialog";
+import { openComponentWizardDialog } from "./open_component_wizard_dialog";
+
+/**
+ * Records that answered "Ja" to the component question and are waiting for
+ * their stage write to commit before the component wizard opens.
+ * Module-level because the model hooks are reassigned per KanbanRecord
+ * instance — per-instance state would be unsafe. Keyed by resId, value is
+ * the target stage id (revalidated after save).
+ */
+const pendingComponentWizard = new Map();
 
 /**
  * Shows a dialog asking if the loan product has been returned.
@@ -48,15 +59,13 @@ patch(KanbanRecord.prototype, {
   setup() {
     super.setup();
     this.dialogService = useService("dialog");
+    this.orm = useService("orm");
+    this.actionService = useService("action");
+    this.notificationService = useService("notification");
+    this.uiService = useService("ui");
 
     const isMaintenanceRequest =
       this.props.record.model.config.resModel === "maintenance.request";
-
-    const userIsExternalContractor =
-      isMaintenanceRequest &&
-      user.hasGroup(
-        "onecore_maintenance_extension.group_external_contractor"
-      );
 
     this.props.record.model.hooks.onWillSaveRecord = async (
       record,
@@ -85,21 +94,62 @@ patch(KanbanRecord.prototype, {
         return false;
       }
 
-      // Existing external contractor validation for "Utförd" stage
-      if (
-        userIsExternalContractor &&
-        targetStageName === "Utförd"
-      ) {
-        const confirmed = await ConfirmDialog(
-          this.dialogService,
-          "Bekräfta ändring",
-          "Är du säker på att du vill ändra statusen till Utförd? Om du gör detta kan du inte ändra tillbaka."
+      if (targetStageName === "Utförd") {
+        // user.hasGroup returns a Promise and MUST be awaited — the previous
+        // unawaited call was always truthy, so the confirm fired for all
+        // users, not just external contractors.
+        const userIsExternalContractor = await user.hasGroup(
+          "onecore_maintenance_extension.group_external_contractor"
         );
 
-        return confirmed;
+        // External contractors keep the plain irreversibility confirm —
+        // component functionality is internal-only for now.
+        if (userIsExternalContractor) {
+          return await ConfirmDialog(
+            this.dialogService,
+            "Bekräfta ändring",
+            "Är du säker på att du vill ändra statusen till Utförd? Om du gör detta kan du inte ändra tillbaka."
+          );
+        }
+
+        // Internal users on apartment ärenden: ask the component question
+        if (record.data.space_caption === "Lägenhet" && record.resId) {
+          const answer = await askComponentQuestion(this.dialogService);
+          if (answer === "abort") {
+            return false;
+          }
+          if (answer === "yes") {
+            pendingComponentWizard.set(record.resId, changes.stage_id);
+          }
+          return true;
+        }
       }
 
       return true;
+    };
+
+    // Opens the component wizard AFTER the stage write committed. NOTE:
+    // model hooks are single-slot — another patch assigning onRecordSaved
+    // would clobber this (nothing else in the repo does today).
+    this.props.record.model.hooks.onRecordSaved = async (record) => {
+      if (!isMaintenanceRequest) {
+        return;
+      }
+      const targetStageId = pendingComponentWizard.get(record.resId);
+      if (targetStageId === undefined) {
+        return;
+      }
+      // Consume before opening — guards against double-fire
+      pendingComponentWizard.delete(record.resId);
+      if (record.data.stage_id?.id === targetStageId) {
+        await openComponentWizardDialog(
+          this.orm,
+          this.actionService,
+          this.notificationService,
+          record.resId,
+          this.uiService
+        );
+      }
     };
   },
 });

--- a/onecore_web_extension/static/src/js/open_component_wizard_dialog.js
+++ b/onecore_web_extension/static/src/js/open_component_wizard_dialog.js
@@ -1,0 +1,51 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+
+/**
+ * Opens the component wizard ("Uppdatera/lägg till Komponent") for a
+ * maintenance request.
+ *
+ * Called after a stage change to "Utförd" has been committed when the user
+ * answered Ja to the component question, and never before — the wizard must
+ * not block or precede the stage write.
+ *
+ * @param {Object} orm - the "orm" service
+ * @param {Object} actionService - the "action" service
+ * @param {Object|null} notificationService - the "notification" service
+ * @param {number} resId - maintenance.request id
+ * @param {Object|null} uiService - the "ui" service (for the loading overlay)
+ */
+export async function openComponentWizardDialog(
+  orm,
+  actionService,
+  notificationService,
+  resId,
+  uiService
+) {
+  // Loading the apartment's components from OneCore can take several seconds;
+  // block the UI with a message so the user sees the wizard is on its way
+  // (without this it reads as "nothing happened" after answering Ja).
+  uiService?.block({ message: _t("Laddar komponenter…") });
+  try {
+    const action = await orm.call(
+      "maintenance.request",
+      "open_component_wizard",
+      [[resId]]
+    );
+    if (action) {
+      await actionService.doAction(action);
+    }
+  } catch (e) {
+    // The stage change already succeeded — never surface this as a blocking
+    // error, just let the user know the wizard could not be opened.
+    console.error("Failed to open component wizard", e);
+    if (notificationService) {
+      notificationService.add(_t("Kunde inte öppna komponentguiden."), {
+        type: "warning",
+      });
+    }
+  } finally {
+    uiService?.unblock();
+  }
+}

--- a/onecore_web_extension/static/src/js/statusbar_field_patch.js
+++ b/onecore_web_extension/static/src/js/statusbar_field_patch.js
@@ -4,11 +4,17 @@ import { patch } from "@web/core/utils/patch";
 import { StatusBarField } from "@web/views/fields/statusbar/statusbar_field";
 import { useService } from "@web/core/utils/hooks";
 import ConfirmDialog from "./confirm_dialog";
+import { askComponentQuestion } from "./component_question_dialog";
+import { openComponentWizardDialog } from "./open_component_wizard_dialog";
 
 patch(StatusBarField.prototype, {
   setup() {
     super.setup();
     this.dialogService = useService("dialog");
+    this.orm = useService("orm");
+    this.actionService = useService("action");
+    this.notificationService = useService("notification");
+    this.uiService = useService("ui");
     this.userIsExternalContractor =
       this.props.record.model.config.resModel === "maintenance.request" &&
       this.props.record.data.user_is_external_contractor;
@@ -55,17 +61,59 @@ patch(StatusBarField.prototype, {
   },
 
   async selectItem(item) {
-    if (this.userIsExternalContractor && item.label === "Utförd") {
+    const record = this.props.record;
+    const isMaintenanceRequest =
+      record.model.config.resModel === "maintenance.request";
+    const goingToUtford =
+      isMaintenanceRequest && item.label === "Utförd" && !item.isSelected;
+
+    if (!goingToUtford) {
+      return super.selectItem(item);
+    }
+
+    // External contractors keep the plain irreversibility confirm —
+    // component functionality is internal-only for now.
+    if (this.userIsExternalContractor) {
       const confirmed = await ConfirmDialog(
         this.dialogService,
         "Bekräfta ändring",
         "Är du säker på att du vill ändra statusen till Utförd? Om du gör detta kan du inte ändra tillbaka."
       );
-      if (confirmed) {
-        super.selectItem(item);
+      if (!confirmed) {
+        return;
       }
-    } else {
-      super.selectItem(item);
+      return super.selectItem(item);
+    }
+
+    // Internal users on apartment ärenden: ask the component question
+    const isApartment =
+      record.data.space_caption === "Lägenhet" && !!record.resId;
+    let answer = null;
+
+    if (isApartment) {
+      answer = await askComponentQuestion(this.dialogService);
+      if (answer === "abort") {
+        return;
+      }
+    }
+
+    // Odoo 19's selectItem awaits record.update() + record.save(); awaiting
+    // here guarantees the stage write committed before the wizard opens.
+    await super.selectItem(item);
+
+    if (
+      answer === "yes" &&
+      record.resId &&
+      !record.dirty &&
+      record.data.stage_id?.id === item.value
+    ) {
+      await openComponentWizardDialog(
+        this.orm,
+        this.actionService,
+        this.notificationService,
+        record.resId,
+        this.uiService
+      );
     }
   },
 });

--- a/onecore_web_extension/static/src/views/component_question_dialog.xml
+++ b/onecore_web_extension/static/src/views/component_question_dialog.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="onecore_web_extension.ComponentQuestionDialog">
+        <Dialog size="'md'" title="'Fastighetskomponent'">
+            <p>
+                Har du bytt ut eller ändrat någon fastighetskomponent i samband
+                med ärendet? Om du svarar Ja får du hjälp att uppdatera
+                komponentens uppgifter i nästa steg.
+            </p>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="onYes">Ja</button>
+                <button class="btn btn-secondary" t-on-click="onNo">Nej</button>
+            </t>
+        </Dialog>
+    </t>
+
+</templates>


### PR DESCRIPTION
## Skapa komponentuppdatering när ärende sätts till Utförd (MIM-1867)

Implements the **Utförd → component update** flow: when an internal user
moves an apartment (Lägenhet) ärende to **Utförd**, a popup asks whether a
property component was replaced/changed. **Ja** opens the existing component
wizard (to update/replace/uninstall in ONECore); **Nej** completes the stage
change as before. Works from both the form statusbar and kanban drag.

📋 Full context, decisions: [MIM-1867](https://linear.app/mimer-onecore/issue/MIM-1867/odoo-har-du-bytt-ut-nagon-fastighetskomponent-flow-when-arende-is)

### What's included
- **Popup at Utförd** (internal users, Lägenhet) → opens the existing
  `maintenance.component.wizard`; reuses all current update/replace logic.
- **Externals unchanged** — keep the plain "Är du säker..." confirm; also
  fixes a latent bug where that confirm fired for all users on kanban drag
  (unawaited `user.hasGroup`).
- **Wizard opens extra-large** + a "Laddar komponenter…" overlay while it loads.
- **Performance**: click→wizard cut from ~35s to ~2.4s — OneCore room/component
  calls now run concurrently (`CoreApi.parallel_get_json`, with timeout +
  serial fallback) and per-component images load lazily only when a component
  is opened.

### Scope notes (per the card)
- Internal-only for now; the external "preliminary change + godkänn" flow and
  the bespoke guided rum→komponent UX are deferred to follow-up cards.

### Testing
- Full onecore test suite green (271 tests, 0 failed).
- Manually verified: Ja/Nej/abort on statusbar + kanban, externals untouched,
  edit→save to ONECore, lazy image render, graceful degrade on missing data.
