### PR TITLE
mim-1873: validate priority_expanded when changing stage - not on creating

### DIFF
--- a/onecore_maintenance_extension/models/services/maintenance_workflow_service.py
+++ b/onecore_maintenance_extension/models/services/maintenance_workflow_service.py
@@ -45,6 +45,7 @@ class MaintenanceStageManager:
             # Auto-transition to "Resurs tilldelad" when user is assigned
             resource_allocated_stage = self._get_stage_by_name("Resurs tilldelad")
             if resource_allocated_stage:
+                self._validate_priority_set(record, resource_allocated_stage.id)
                 return {"stage_id": resource_allocated_stage.id}
 
         elif new_user_id is False and record.stage_id.name != "Avslutad":

--- a/onecore_maintenance_extension/models/services/maintenance_workflow_service.py
+++ b/onecore_maintenance_extension/models/services/maintenance_workflow_service.py
@@ -9,11 +9,15 @@ from markupsafe import Markup
 class MaintenanceStageManager:
     """Service for managing maintenance request workflow and stage transitions."""
 
+    PRIORITY_EXEMPT_STAGES = ("Väntar på handläggning", "Avslutad")
+
     def __init__(self, env):
         self.env = env
 
     def handle_stage_change(self, record, new_stage_id, vals=None):
         """Handle all logic when stage changes. Returns dict of field updates."""
+        self._validate_priority_set(record, new_stage_id)
+
         # Handle resource assignment workflow
         # Check both the current user_id and any user_id being set in the same write
         has_user = record.user_id or (vals and vals.get("user_id"))
@@ -59,6 +63,17 @@ class MaintenanceStageManager:
         if new_stage_id not in allowed_stages.ids:
             raise exceptions.UserError(
                 "Ingen resurs är tilldelad. Vänligen välj en resurs."
+            )
+
+    def _validate_priority_set(self, record, new_stage_id):
+        """Validate priority_expanded is set before moving to a handling stage."""
+        new_stage = self.env["maintenance.stage"].browse(new_stage_id)
+        if new_stage.name in self.PRIORITY_EXEMPT_STAGES:
+            return
+        if not record.priority_expanded:
+            raise exceptions.UserError(
+                _("Prioritet måste anges innan ärendet flyttas till '%s'.")
+                % new_stage.name
             )
 
     def handle_initial_user_assignment(self, request):

--- a/onecore_maintenance_extension/tests/models/services/test_maintenance_workflow_service.py
+++ b/onecore_maintenance_extension/tests/models/services/test_maintenance_workflow_service.py
@@ -160,6 +160,67 @@ class TestMaintenanceStageManager(StageTestMixin, TransactionCase):
         self.assertTrue(request.performed_date)
         self.assertGreaterEqual(request.performed_date, first_performed_date)
 
+    def test_priority_required_for_resurs_tilldelad(self):
+        """Moving from 'Väntar på handläggning' to 'Resurs tilldelad' without priority raises."""
+        request = create_maintenance_request(
+            self.env,
+            stage_id=self.stage_vantar.id,
+            priority_expanded=False,
+            user_id=self.internal_user.id,
+        )
+        # Initial user assignment auto-moved stage to 'Resurs tilldelad'.
+        # Move back to 'Väntar' (exempt) to isolate the forward transition.
+        request.with_user(self.internal_user).write({"stage_id": self.stage_vantar.id})
+
+        with self.assertRaisesRegex(UserError, "Prioritet måste anges"):
+            request.with_user(self.internal_user).write(
+                {"stage_id": self.stage_tilldelad.id}
+            )
+
+    def test_priority_required_for_utford(self):
+        """Moving to 'Utförd' without priority raises."""
+        request = create_maintenance_request(
+            self.env,
+            stage_id=self.stage_vantar.id,
+            priority_expanded=False,
+            user_id=self.internal_user.id,
+        )
+        # Initial user assignment auto-moved stage to 'Resurs tilldelad'.
+        # Move back to 'Väntar' (exempt) to isolate the forward transition.
+        request.with_user(self.internal_user).write({"stage_id": self.stage_vantar.id})
+
+        with self.assertRaisesRegex(UserError, "Prioritet måste anges"):
+            request.with_user(self.internal_user).write(
+                {"stage_id": self.stage_utford.id}
+            )
+
+    def test_priority_not_required_for_avslutad(self):
+        """Closing directly to 'Avslutad' without priority is allowed."""
+        request = create_maintenance_request(
+            self.env,
+            stage_id=self.stage_vantar.id,
+            priority_expanded=False,
+        )
+
+        request.with_user(self.internal_user).write(
+            {"stage_id": self.stage_avslutad.id}
+        )
+
+        self.assertEqual(request.stage_id, self.stage_avslutad)
+
+    def test_priority_not_required_when_staying_in_vantar(self):
+        """Writes that don't change stage succeed with empty priority."""
+        request = create_maintenance_request(
+            self.env,
+            stage_id=self.stage_vantar.id,
+            priority_expanded=False,
+        )
+
+        request.with_user(self.internal_user).write({"description": "uppdaterad"})
+
+        self.assertFalse(request.priority_expanded)
+        self.assertEqual(request.stage_id, self.stage_vantar)
+
 
 @tagged("onecore")
 class TestFieldChangeTracker(TransactionCase):

--- a/onecore_maintenance_extension/tests/models/services/test_maintenance_workflow_service.py
+++ b/onecore_maintenance_extension/tests/models/services/test_maintenance_workflow_service.py
@@ -162,15 +162,18 @@ class TestMaintenanceStageManager(StageTestMixin, TransactionCase):
 
     def test_priority_required_for_resurs_tilldelad(self):
         """Moving from 'Väntar på handläggning' to 'Resurs tilldelad' without priority raises."""
+        # Create with a priority + user so the auto-transition during create
+        # succeeds, then clear priority in the same write that returns the
+        # request to 'Väntar' (exempt). This leaves a record that has a user
+        # assigned (so _validate_unassigned_resource passes) but no priority.
         request = create_maintenance_request(
             self.env,
             stage_id=self.stage_vantar.id,
-            priority_expanded=False,
             user_id=self.internal_user.id,
         )
-        # Initial user assignment auto-moved stage to 'Resurs tilldelad'.
-        # Move back to 'Väntar' (exempt) to isolate the forward transition.
-        request.with_user(self.internal_user).write({"stage_id": self.stage_vantar.id})
+        request.with_user(self.internal_user).write(
+            {"stage_id": self.stage_vantar.id, "priority_expanded": False}
+        )
 
         with self.assertRaisesRegex(UserError, "Prioritet måste anges"):
             request.with_user(self.internal_user).write(
@@ -182,12 +185,11 @@ class TestMaintenanceStageManager(StageTestMixin, TransactionCase):
         request = create_maintenance_request(
             self.env,
             stage_id=self.stage_vantar.id,
-            priority_expanded=False,
             user_id=self.internal_user.id,
         )
-        # Initial user assignment auto-moved stage to 'Resurs tilldelad'.
-        # Move back to 'Väntar' (exempt) to isolate the forward transition.
-        request.with_user(self.internal_user).write({"stage_id": self.stage_vantar.id})
+        request.with_user(self.internal_user).write(
+            {"stage_id": self.stage_vantar.id, "priority_expanded": False}
+        )
 
         with self.assertRaisesRegex(UserError, "Prioritet måste anges"):
             request.with_user(self.internal_user).write(

--- a/onecore_maintenance_extension/tests/models/services/test_maintenance_workflow_service.py
+++ b/onecore_maintenance_extension/tests/models/services/test_maintenance_workflow_service.py
@@ -221,6 +221,34 @@ class TestMaintenanceStageManager(StageTestMixin, TransactionCase):
         self.assertFalse(request.priority_expanded)
         self.assertEqual(request.stage_id, self.stage_vantar)
 
+    def test_auto_transition_via_user_assignment_requires_priority(self):
+        """Assigning a user while in 'Väntar på handläggning' without priority must raise."""
+        request = create_maintenance_request(
+            self.env,
+            stage_id=self.stage_vantar.id,
+            priority_expanded=False,
+        )
+
+        with self.assertRaisesRegex(UserError, "Prioritet måste anges"):
+            request.with_user(self.internal_user).write(
+                {"user_id": self.internal_user.id}
+            )
+
+    def test_auto_transition_via_user_assignment_passes_when_priority_set(self):
+        """Assigning a user when priority is set auto-transitions to 'Resurs tilldelad'."""
+        request = create_maintenance_request(
+            self.env,
+            stage_id=self.stage_vantar.id,
+            priority_expanded="7",
+        )
+
+        request.with_user(self.internal_user).write(
+            {"user_id": self.internal_user.id}
+        )
+
+        self.assertEqual(request.stage_id, self.stage_tilldelad)
+        self.assertEqual(request.user_id, self.internal_user)
+
 
 @tagged("onecore")
 class TestFieldChangeTracker(TransactionCase):


### PR DESCRIPTION
Changes based on discussion on slack ... incoming maintenance requests from mimer.nu for example should not have priority set. Having priority_expanded required creates an odoo RPC error if the field is missing.

We decided to do the validation when the ticket is moved between stages